### PR TITLE
fix: 修复游戏仓库页面虚拟滚动容器查找失败导致无限加载

### DIFF
--- a/src/components/Cards/VirtualCardsGrid.tsx
+++ b/src/components/Cards/VirtualCardsGrid.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useMemo, useRef, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Virtuoso } from "react-virtuoso";
 import { useStore } from "@/store/appStore";
 import { CardItem } from "./CardItem";
@@ -20,6 +20,23 @@ function getColumnCount(): number {
 	return 3;
 }
 
+/**
+ * 从当前元素向上遍历 DOM 树，找到第一个具有 overflow-y: auto 或 scroll 的祖先元素。
+ * 相比 querySelector("main")，不依赖特定标签名，避免嵌套 <main> 导致的错误匹配。
+ */
+function findScrollableParent(el: HTMLElement | null): HTMLElement | null {
+	let current = el?.parentElement ?? null;
+	while (current) {
+		const style = window.getComputedStyle(current);
+		const overflowY = style.overflowY;
+		if (overflowY === "auto" || overflowY === "scroll") {
+			return current;
+		}
+		current = current.parentElement;
+	}
+	return null;
+}
+
 interface VirtualCardsGridProps {
 	gameIds: number[];
 }
@@ -28,18 +45,34 @@ interface VirtualCardsGridProps {
  * VirtualCardsGrid - 虚拟化卡片网格（用于 LibrariesPage）
  *
  * 滚动恢复：
- * - 保存：scroll 事件中缓存 main.scrollTop - wrapper 相对偏移（列表内坐标），
+ * - 保存：scroll 事件中缓存 scrollParent.scrollTop - wrapper 相对偏移，
  *         unmount 时写入 Zustand（ref 值，避免 react-router 重置 DOM 的时序问题）
  * - 恢复：initialScrollTop 直接传列表内偏移，Virtuoso 初始化时同步生效
  */
 export const VirtualCardsGrid = memo(({ gameIds }: VirtualCardsGridProps) => {
 	const { controls, getCardProps } = useCardsController({ gameIds });
 
-	const [mainEl, setMainEl] = useState<HTMLElement | null>(null);
 	const virtuosoWrapperRef = useRef<HTMLDivElement>(null);
+	const [scrollParent, setScrollParent] = useState<HTMLElement | null>(null);
 
+	// 从 wrapper 向上查找可滚动的祖先容器（DashboardLayout 的 <main>）
+	// 使用 requestAnimationFrame 确保 DOM 已完全渲染（PageContainer 等）后再查找
 	useEffect(() => {
-		setMainEl(document.querySelector("main"));
+		const tryFind = () => {
+			const found = findScrollableParent(virtuosoWrapperRef.current);
+			if (found) {
+				setScrollParent(found);
+				return;
+			}
+			// 重试一次——PageContainer 内部的 DOM 可能还未完成布局
+			requestAnimationFrame(() => {
+				const retry = findScrollableParent(virtuosoWrapperRef.current);
+				if (retry) setScrollParent(retry);
+			});
+		};
+		// 延迟一帧确保 DashboardLayout + PageContainer 的 DOM 全部就位
+		const raf = requestAnimationFrame(tryFind);
+		return () => cancelAnimationFrame(raf);
 	}, []);
 
 	// 首次 mount 时读取，仅用于 initialScrollTop（Virtuoso 初始化时同步生效）
@@ -68,50 +101,66 @@ export const VirtualCardsGrid = memo(({ gameIds }: VirtualCardsGridProps) => {
 	const lastScrollTop = useRef(0);
 
 	useEffect(() => {
-		if (!mainEl) return;
+		if (!scrollParent) return;
 
-		// wrapper 相对 main 内容区的固定偏移（含 margin），算一次
+		// wrapper 相对 scrollParent 内容区的固定偏移（含 margin），算一次
 		const wrapperOffsetTop =
 			(virtuosoWrapperRef.current?.getBoundingClientRect().top ?? 0) -
-			mainEl.getBoundingClientRect().top +
-			mainEl.scrollTop;
+			scrollParent.getBoundingClientRect().top +
+			scrollParent.scrollTop;
 
 		const onScroll = () => {
-			lastScrollTop.current = Math.max(0, mainEl.scrollTop - wrapperOffsetTop);
+			lastScrollTop.current = Math.max(
+				0,
+				scrollParent.scrollTop - wrapperOffsetTop,
+			);
 		};
 
-		mainEl.addEventListener("scroll", onScroll, { passive: true });
+		scrollParent.addEventListener("scroll", onScroll, { passive: true });
 		return () => {
-			mainEl.removeEventListener("scroll", onScroll);
+			scrollParent.removeEventListener("scroll", onScroll);
 			useStore.getState().setLibrariesScrollTop(lastScrollTop.current);
 		};
-	}, [mainEl]);
+	}, [scrollParent]);
+
+	const renderRow = useCallback(
+		(rowIndex: number) => (
+			<div
+				className="grid gap-4 pb-4"
+				style={{
+					gridTemplateColumns: `repeat(${columns}, 1fr)`,
+				}}
+			>
+				{rows[rowIndex].map((gameId) => {
+					const props = getCardProps(gameId);
+					return <CardItem key={gameId} {...props} />;
+				})}
+			</div>
+		),
+		[rows, columns, getCardProps],
+	);
+
+	// 如果还没找到滚动父容器，先渲染空占位，等 useEffect 触发更新后再挂载 Virtuoso
+	if (!scrollParent) {
+		return (
+			<>
+				{controls}
+				<div ref={virtuosoWrapperRef} className="flex-1 min-h-0" />
+			</>
+		);
+	}
 
 	return (
 		<>
 			{controls}
 			<div ref={virtuosoWrapperRef} className="flex-1 min-h-0">
-				{mainEl && (
-					<Virtuoso
-						customScrollParent={mainEl}
-						totalCount={rows.length}
-						overscan={400}
-						initialScrollTop={savedScrollTop}
-						itemContent={(rowIndex) => (
-							<div
-								className="grid gap-4 pb-4"
-								style={{
-									gridTemplateColumns: `repeat(${columns}, 1fr)`,
-								}}
-							>
-								{rows[rowIndex].map((gameId) => {
-									const props = getCardProps(gameId);
-									return <CardItem key={gameId} {...props} />;
-								})}
-							</div>
-						)}
-					/>
-				)}
+				<Virtuoso
+					customScrollParent={scrollParent}
+					totalCount={rows.length}
+					overscan={400}
+					initialScrollTop={savedScrollTop}
+					itemContent={renderRow}
+				/>
 			</div>
 		</>
 	);

--- a/src/hooks/features/games/useGameListFacade.ts
+++ b/src/hooks/features/games/useGameListFacade.ts
@@ -124,7 +124,7 @@ export function useGameListFacade() {
 	return {
 		filteredGames,
 		gameIds,
-		isLoading: gameIdListQuery.isLoading,
+		isLoading: allGamesQuery.isLoading || gameIdListQuery.isLoading,
 	};
 }
 

--- a/src/pages/LibrariesPage.tsx
+++ b/src/pages/LibrariesPage.tsx
@@ -1,7 +1,41 @@
+import { Box, CircularProgress, Typography } from "@mui/material";
+import { useTranslation } from "react-i18next";
 import { VirtualCardsGrid } from "@/components/Cards";
 import { useGameListFacade } from "@/hooks/features/games/useGameListFacade";
 
 export const Libraries: React.FC = () => {
-	const { gameIds } = useGameListFacade();
+	const { t } = useTranslation();
+	const { gameIds, isLoading } = useGameListFacade();
+
+	if (isLoading) {
+		return (
+			<Box
+				display="flex"
+				justifyContent="center"
+				alignItems="center"
+				minHeight="50vh"
+			>
+				<CircularProgress />
+			</Box>
+		);
+	}
+
+	if (gameIds.length === 0) {
+		return (
+			<Box
+				display="flex"
+				justifyContent="center"
+				alignItems="center"
+				minHeight="50vh"
+			>
+				<Typography variant="h6" color="text.secondary">
+					{t("pages.Libraries.empty", {
+						defaultValue: "暂无游戏，请先添加游戏",
+					})}
+				</Typography>
+			</Box>
+		);
+	}
+
 	return <VirtualCardsGrid gameIds={gameIds} />;
 };


### PR DESCRIPTION
- VirtualCardsGrid: 用 DOM 向上遍历替代 querySelector("main") 查找滚动容器
- useGameListFacade: isLoading 合并 allGamesQuery 和 gameIdListQuery 两条查询
- LibrariesPage: 添加加载态和空数据提示
[bug-report.html](https://github.com/user-attachments/files/27572786/bug-report.html)
