### PR TITLE
fix(scan): raise default bulk scan depth to 3 and rescan on depth change

### DIFF
--- a/src/components/AddModal/BulkImportTab.tsx
+++ b/src/components/AddModal/BulkImportTab.tsx
@@ -51,7 +51,7 @@ interface BulkImportTabProps {
 	onClose: () => void;
 }
 
-const DEFAULT_SCAN_DEPTH = 2;
+const DEFAULT_SCAN_DEPTH = 3;
 const SCAN_DEPTH_OPTIONS = [2, 3, 4, 5] as const;
 const BULK_API_SOURCE_OPTIONS = REGISTERED_SOURCE_KEYS.map((source) => ({
 	value: source,
@@ -177,29 +177,43 @@ const BulkImportTab = ({ hidden, onClose }: BulkImportTabProps) => {
 		onClose();
 	}, [isMatchingMetadata, onClose, t]);
 
+	const scanSelectedFolder = useCallback(
+		async (selectedRootPath: string, maxDepth: number) => {
+			setIsScanningDirectories(true);
+			try {
+				const subdirs = await fileService.scanDirectoryForGames(
+					selectedRootPath,
+					maxDepth,
+				);
+				setItems(
+					subdirs.map((dir) => ({
+						...dir,
+						status: "pending",
+						selectedExe:
+							dir.executables.length > 0 ? dir.executables[0] : undefined,
+					})),
+				);
+			} catch (error) {
+				snackbar.error(getUserErrorMessage(error, t));
+			} finally {
+				setIsScanningDirectories(false);
+			}
+		},
+		[t],
+	);
+
 	const scanFolder = async () => {
 		const result = await handleFolder();
 		if (!result) return;
 
 		setRootPath(result);
-		setIsScanningDirectories(true);
-		try {
-			const subdirs = await fileService.scanDirectoryForGames(
-				result,
-				scanMaxDepth,
-			);
-			setItems(
-				subdirs.map((dir) => ({
-					...dir,
-					status: "pending",
-					selectedExe:
-						dir.executables.length > 0 ? dir.executables[0] : undefined,
-				})),
-			);
-		} catch (error) {
-			snackbar.error(getUserErrorMessage(error, t));
-		} finally {
-			setIsScanningDirectories(false);
+		await scanSelectedFolder(result, scanMaxDepth);
+	};
+
+	const handleScanDepthChange = (nextDepth: number) => {
+		setScanMaxDepth(nextDepth);
+		if (rootPath) {
+			void scanSelectedFolder(rootPath, nextDepth);
 		}
 	};
 
@@ -546,7 +560,7 @@ const BulkImportTab = ({ hidden, onClose }: BulkImportTabProps) => {
 									value={scanMaxDepth}
 									label={t("components.BulkImportModal.scanDepth", "扫描深度")}
 									onChange={(event) =>
-										setScanMaxDepth(Number(event.target.value))
+										handleScanDepthChange(Number(event.target.value))
 									}
 								>
 									{SCAN_DEPTH_OPTIONS.map((depth) => (


### PR DESCRIPTION
## What

- 把批量导入的默认扫描深度从 2 提到 3
- 切换扫描深度时自动重新扫描，无需重新选择文件夹

## Why

原版默认深度 2 只覆盖选中目录下一层。galgame 库常见嵌套结构（系列子目录、同名嵌套、子文件夹包装）的可执行文件通常位于深度 3，深度 2 扫不到，用户看不到这些游戏。

切换深度的下拉框原版只更新 state，不触发 rescan，必须重新点"选择文件夹"才会用新深度扫描——容易让人误以为切深度无效。

## How

- `BulkImportTab.tsx`: `DEFAULT_SCAN_DEPTH` 从 2 改为 3
- `BulkImportTab.tsx`: 抽出 `scanSelectedFolder`，新增 `handleScanDepthChange`，切换深度时若有已选根目录则自动 rescan

## Testing

- `npm run typecheck`
- `npx biome check --formatter-enabled=false src/components/AddModal/BulkImportTab.tsx`
- `git diff --check`

> 注：原 PR #63 的 scan.rs 改动（existing_game_dirs_from_localpaths / root_exes / ResultTable 兼容）经复盘基于错误诊断，已全部撤回。
