### PR TITLE
feat: add external startup monitor

### DIFF
--- a/src-tauri/src/game/launch/linux.rs
+++ b/src-tauri/src/game/launch/linux.rs
@@ -25,6 +25,23 @@ pub struct StopResult {
     terminated_count: u32,
 }
 
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ExternalRunningGameMatch {
+    game_id: u32,
+    process_id: u32,
+    message: String,
+}
+
+#[command]
+pub async fn adopt_external_running_games<R: Runtime>(
+    _app_handle: AppHandle<R>,
+    _db: State<'_, DatabaseConnection>,
+    _time_tracking_mode: TimeTrackingMode,
+) -> Result<Vec<ExternalRunningGameMatch>, String> {
+    // linux的tauri权限可能有点复杂,暂时不动linux
+    Ok(Vec::new())
+}
+
 #[command]
 pub async fn launch_game<R: Runtime>(
     app_handle: AppHandle<R>,

--- a/src-tauri/src/game/launch/windows.rs
+++ b/src-tauri/src/game/launch/windows.rs
@@ -1,12 +1,13 @@
 use crate::database::dto::UpdateSettingsData;
 use crate::database::repository::games_repository::GamesRepository;
+use crate::entity::prelude::Games;
 use crate::database::repository::settings_repository::{DbSettingsExt, SettingsRepository};
 use crate::game::local_path::{GameLaunchTarget, resolve_launch_target};
-use crate::game::monitor::{TimeTrackingMode, monitor_game, stop_game_session};
+use crate::game::monitor::{TimeTrackingMode, is_game_monitored, monitor_game, stop_game_session};
 use crate::utils::command_ext::CommandGuiExt;
-use sea_orm::DatabaseConnection;
+use sea_orm::{DatabaseConnection, EntityTrait};
 use serde::{Deserialize, Serialize};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use tauri::{AppHandle, Runtime, State, command};
 use {
@@ -57,6 +58,247 @@ pub struct StopResult {
     success: bool,
     message: String,
     terminated_count: u32,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ExternalRunningGameMatch {
+    game_id: u32,
+    process_id: u32,
+    message: String,
+}
+
+#[command]
+pub async fn adopt_external_running_games<R: Runtime>(
+    app_handle: AppHandle<R>,
+    db: State<'_, DatabaseConnection>,
+    time_tracking_mode: TimeTrackingMode,
+) -> Result<Vec<ExternalRunningGameMatch>, String> {
+    let games = Games::find()
+        .all(db.inner())
+        .await
+        .map_err(|e| format!("查询游戏列表失败: {}", e))?;
+
+    let mut matches = Vec::new();
+    for game in games {
+        let Some(localpath) = game.localpath.as_deref() else {
+            continue;
+        };
+        let launch_target = resolve_launch_target(Some(localpath));
+        let GameLaunchTarget::NormalExecutable {
+            executable_path,
+            detection_dir,
+            ..
+        } = launch_target
+        else {
+            continue;
+        };
+
+        let game_id = match u32::try_from(game.id) {
+            Ok(id) => id,
+            Err(_) => continue,
+        };
+        if is_game_monitored(game_id) {
+            continue;
+        }
+
+        let Some(process_id) = find_external_process_for_game(&executable_path, &detection_dir) else {
+            continue;
+        };
+
+        let detection_dir_str = detection_dir.to_string_lossy().to_string();
+        info!(
+            "检测到外部启动游戏 game_id={} pid={} detection_dir={}",
+            game_id, process_id, detection_dir_str
+        );
+
+        monitor_game(
+            app_handle.clone(),
+            db.inner().clone(),
+            time_tracking_mode,
+            game_id,
+            process_id,
+            detection_dir_str,
+        )
+        .await;
+
+        matches.push(ExternalRunningGameMatch {
+            game_id,
+            process_id,
+            message: format!("已接管外部启动的游戏 {}", game_id),
+        });
+    }
+
+    Ok(matches)
+}
+
+fn find_external_process_for_game(executable_path: &Path, detection_dir: &Path) -> Option<u32> {
+    let manager_pid = std::process::id();
+    let executable_name = executable_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .map(|name| name.to_string());
+    let target_exe = normalize_path_string(executable_path);
+    let target_dir = normalize_path_string(detection_dir);
+    let canonical_exe = std::fs::canonicalize(executable_path)
+        .ok()
+        .map(|path| normalize_path_string(&path));
+    let canonical_dir = std::fs::canonicalize(detection_dir)
+        .ok()
+        .map(|path| normalize_path_string(&path));
+    // 支持官方启动器安装的路径(即防止启动器中的路径是给的官方启动器，从而直接查找官方启动器下的子目录exe)
+    let parent_dir = detection_dir.parent().map(normalize_path_string);
+    let canonical_parent_dir = detection_dir
+        .parent()
+        .and_then(|path| std::fs::canonicalize(path).ok())
+        .map(|path| normalize_path_string(&path));
+
+    enumerate_processes()
+        .into_iter()
+        .filter(|process| process.pid != manager_pid)
+        .find(|process| {
+            let path_str = normalize_path_string(&process.path);
+            let process_name_matches = executable_name
+                .as_ref()
+                .is_some_and(|name| process.name.eq_ignore_ascii_case(name));
+            path_str.eq_ignore_ascii_case(&target_exe)
+                || canonical_exe
+                    .as_ref()
+                    .is_some_and(|path| path_str.eq_ignore_ascii_case(path))
+                || is_sub_path_ignore_case(&path_str, &target_dir)
+                || canonical_dir
+                    .as_ref()
+                    .is_some_and(|path| is_sub_path_ignore_case(&path_str, path))
+                || parent_dir
+                    .as_ref()
+                    .is_some_and(|path| is_sub_path_ignore_case(&path_str, path))
+                || canonical_parent_dir
+                    .as_ref()
+                    .is_some_and(|path| is_sub_path_ignore_case(&path_str, path))
+                || (process_name_matches
+                    && process
+                        .path
+                        .parent()
+                        .is_some_and(|parent| is_sub_path_ignore_case(&normalize_path_string(parent), &target_dir)))
+        })
+        .map(|process| process.pid)
+}
+
+#[derive(Debug)]
+struct RunningProcessInfo {
+    pid: u32,
+    name: String,
+    path: PathBuf,
+}
+
+fn enumerate_processes() -> Vec<RunningProcessInfo> {
+    use std::mem;
+    use windows::Win32::{
+        Foundation::CloseHandle,
+        System::Diagnostics::ToolHelp::{
+            CREATE_TOOLHELP_SNAPSHOT_FLAGS, CreateToolhelp32Snapshot, PROCESSENTRY32W,
+            Process32FirstW, Process32NextW,
+        },
+    };
+
+    let mut processes = Vec::new();
+    unsafe {
+        let snapshot = match CreateToolhelp32Snapshot(
+            CREATE_TOOLHELP_SNAPSHOT_FLAGS(0x00000002),
+            0,
+        ) {
+            Ok(h) if !h.is_invalid() => h,
+            _ => return processes,
+        };
+
+        let mut entry = PROCESSENTRY32W {
+            dwSize: mem::size_of::<PROCESSENTRY32W>() as u32,
+            ..Default::default()
+        };
+
+        if Process32FirstW(snapshot, &mut entry).is_ok() {
+            loop {
+                let pid = entry.th32ProcessID;
+                let name_end = entry
+                    .szExeFile
+                    .iter()
+                    .position(|&c| c == 0)
+                    .unwrap_or(entry.szExeFile.len());
+                let name = String::from_utf16_lossy(&entry.szExeFile[..name_end]);
+                if pid > 0 && let Some(path) = get_process_executable_path(pid) {
+                    processes.push(RunningProcessInfo { pid, name, path });
+                }
+
+                if Process32NextW(snapshot, &mut entry).is_err() {
+                    break;
+                }
+            }
+        }
+
+        let _ = CloseHandle(snapshot);
+    }
+
+    processes
+}
+
+fn normalize_path_string(path: &Path) -> String {
+    path.to_string_lossy().replace('/', "\\")
+}
+
+fn is_sub_path_ignore_case(path: &str, base_dir: &str) -> bool {
+    let path_bytes = path.as_bytes();
+    let base_bytes = base_dir.as_bytes();
+    let path_len = path_bytes.len();
+    let base_len = base_bytes.len();
+
+    if path_len < base_len {
+        return false;
+    }
+
+    if !path_bytes[..base_len].eq_ignore_ascii_case(base_bytes) {
+        return false;
+    }
+
+    if path_len == base_len {
+        return true;
+    }
+
+    if base_dir.ends_with('\\') || base_dir.ends_with('/') {
+        return true;
+    }
+
+    let next_char = path_bytes[base_len];
+    next_char == b'\\' || next_char == b'/'
+}
+
+fn get_process_executable_path(pid: u32) -> Option<PathBuf> {
+    use windows::Win32::{
+        Foundation::CloseHandle,
+        System::Threading::{OpenProcess, PROCESS_NAME_WIN32, PROCESS_QUERY_LIMITED_INFORMATION, QueryFullProcessImageNameW},
+    };
+
+    unsafe {
+        let handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, pid).ok()?;
+        if handle.is_invalid() {
+            return None;
+        }
+
+        let mut buffer = vec![0u16; 32768];
+        let mut size = buffer.len() as u32;
+        let result = QueryFullProcessImageNameW(
+            handle,
+            PROCESS_NAME_WIN32,
+            windows::core::PWSTR(buffer.as_mut_ptr()),
+            &mut size,
+        );
+        let _ = CloseHandle(handle);
+
+        if result.is_err() || size == 0 {
+            return None;
+        }
+
+        buffer.truncate(size as usize);
+        Some(PathBuf::from(String::from_utf16_lossy(&buffer)))
+    }
 }
 
 // ================= Windows键盘模拟支持 =================
@@ -115,7 +357,7 @@ mod keyboard_simulator {
 mod win_elevated_launch {
     use std::ffi::OsStr;
     use std::os::windows::ffi::OsStrExt;
-    use std::path::Path;
+    use std::path::{Path, PathBuf};
 
     use windows::Win32::Foundation::CloseHandle;
     use windows::Win32::System::Threading::GetProcessId;

--- a/src-tauri/src/game/launch/windows.rs
+++ b/src-tauri/src/game/launch/windows.rs
@@ -357,7 +357,7 @@ mod keyboard_simulator {
 mod win_elevated_launch {
     use std::ffi::OsStr;
     use std::os::windows::ffi::OsStrExt;
-    use std::path::{Path, PathBuf};
+    use std::path::{Path};
 
     use windows::Win32::Foundation::CloseHandle;
     use windows::Win32::System::Threading::GetProcessId;

--- a/src-tauri/src/game/monitor/linux.rs
+++ b/src-tauri/src/game/monitor/linux.rs
@@ -80,6 +80,13 @@ pub async fn monitor_game<R: Runtime>(
 // 公共 API
 // ============================================================================
 
+/// 判断指定游戏是否已经有活跃监控会话。
+/// Linux 版本的监控由 systemd scope 管理，此处外部启动接管暂不支持。
+pub fn is_game_monitored(_game_id: u32) -> bool {
+    false
+}
+
+
 /// 停止指定游戏的监控并终止所有相关进程
 ///
 /// # Arguments

--- a/src-tauri/src/game/monitor/windows.rs
+++ b/src-tauri/src/game/monitor/windows.rs
@@ -131,6 +131,11 @@ fn unregister_session(game_id: u32) {
     get_sessions().write().remove(&game_id);
 }
 
+/// 判断指定游戏是否已经有活跃监控会话。
+pub fn is_game_monitored(game_id: u32) -> bool {
+    get_sessions().read().contains_key(&game_id)
+}
+
 // ============================================================================
 // 公共 API
 // ============================================================================

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -12,7 +12,7 @@ use backup::savedata::{
 use database::*;
 use game::cover::custom::{delete_game_covers, import_clipboard_image_to_temp};
 use game::cover::{delete_cloud_cache, register_game_cover_protocol};
-use game::launch::{launch_game, stop_game};
+use game::launch::{adopt_external_running_games, launch_game, stop_game};
 use game::scan::scan_directory_for_games;
 use migration::MigratorTrait;
 use tauri::Manager;
@@ -60,6 +60,7 @@ pub fn run() {
             // 工具类 commands
             launch_game,
             stop_game,
+            adopt_external_running_games,
             open_directory,
             resolve_local_path_directory,
             resolve_dropped_local_path,

--- a/src/pages/Settings/SettingsPage.tsx
+++ b/src/pages/Settings/SettingsPage.tsx
@@ -33,6 +33,7 @@ import {
 	LinuxLaunchCommandSettings,
 	LogLevelSettings,
 	ProxySettings,
+	ExternalLaunchMonitorSettings,
 	TimeTrackingModeSettings,
 } from "./SystemSettings";
 
@@ -163,6 +164,7 @@ export const Settings: React.FC = () => {
 						<CloseBtnSettings />
 						<SettingsDivider />
 						<TimeTrackingModeSettings />
+						<ExternalLaunchMonitorSettings />
 						{import.meta.env.TAURI_ENV_PLATFORM === "linux" && (
 							<>
 								<SettingsDivider />

--- a/src/pages/Settings/SystemSettings.tsx
+++ b/src/pages/Settings/SystemSettings.tsx
@@ -233,6 +233,36 @@ export const CloseBtnSettings = () => {
 	);
 };
 
+
+export const ExternalLaunchMonitorSettings = () => {
+	const { t } = useTranslation();
+	const { externalLaunchMonitorEnabled, setExternalLaunchMonitorEnabled } = useStore(
+		useShallow((s) => ({
+			externalLaunchMonitorEnabled: s.externalLaunchMonitorEnabled,
+			setExternalLaunchMonitorEnabled: s.setExternalLaunchMonitorEnabled,
+		})),
+	);
+
+	return (
+		<SettingsItem
+			title={t(
+				"pages.Settings.externalLaunchMonitor.title",
+				"监控外部启动的游戏",
+			)}
+			description={t(
+				"pages.Settings.externalLaunchMonitor.description",
+				"开启后，ReinaManager 会定时扫描本机正在运行的游戏进程，并在匹配到游戏库中的本地路径时自动接管计时。默认关闭。",
+			)}
+		>
+			<Switch
+				checked={externalLaunchMonitorEnabled}
+				onChange={(e) => setExternalLaunchMonitorEnabled(e.target.checked)}
+				color="primary"
+			/>
+		</SettingsItem>
+	);
+};
+
 export const TimeTrackingModeSettings = () => {
 	const { t } = useTranslation();
 	const timeTrackingMode = useStore((s) => s.timeTrackingMode);

--- a/src/services/game/gameStats.ts
+++ b/src/services/game/gameStats.ts
@@ -14,6 +14,7 @@ export type TimeUpdateCallback = (
 	seconds: number,
 ) => void;
 export type SessionEndCallback = (gameId: number, minutes: number) => void;
+export type SessionStartCallback = (gameId: number, processId: number, startTime: number) => void;
 
 // 获取游戏统计信息 - 使用后端服务
 export async function getGameStatistics(
@@ -144,6 +145,7 @@ export async function getFormattedGameStats(
 export function initGameTimeTracking(
 	onTimeUpdate?: TimeUpdateCallback,
 	onSessionEnd?: SessionEndCallback,
+	onSessionStart?: SessionStartCallback,
 ): () => void {
 	// 游戏会话开始
 	const unlistenStart = listen<{
@@ -151,8 +153,9 @@ export function initGameTimeTracking(
 		processId: number;
 		startTime: number;
 	}>("game-session-started", (event) => {
-		const { gameId } = event.payload;
+		const { gameId, processId, startTime } = event.payload;
 		console.log(`游戏 ${gameId} 开始运行`);
+		onSessionStart?.(gameId, processId, startTime);
 	});
 
 	// 游戏时间更新事件监听

--- a/src/services/invoke/statsService.ts
+++ b/src/services/invoke/statsService.ts
@@ -19,6 +19,12 @@ export interface StopGameResult {
 	terminated_count: number;
 }
 
+export interface ExternalRunningGameMatch {
+	game_id: number;
+	process_id: number;
+	message: string;
+}
+
 class StatsService extends BaseService {
 	/**
 	 * 启动游戏并开始监控
@@ -42,6 +48,18 @@ class StatsService extends BaseService {
 		return this.invoke<StopGameResult>("stop_game", {
 			gameId,
 		});
+	}
+
+	/**
+	 * 扫描并接管外部启动的游戏进程
+	 */
+	async adoptExternalRunningGames(
+		timeTrackingMode: "playtime" | "elapsed",
+	): Promise<ExternalRunningGameMatch[]> {
+		return this.invoke<ExternalRunningGameMatch[]>(
+			"adopt_external_running_games",
+			{ timeTrackingMode },
+		);
 	}
 
 	/**

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -34,7 +34,11 @@ import {
 	APP_STORE_VERSION,
 	migrateAppStorePersistedState,
 } from "./appStoreMigrations";
-import { initializeGamePlayTracking } from "./gamePlayStore";
+import {
+	disposeExternalRunningGameScan,
+	initializeExternalRunningGameScan,
+	initializeGamePlayTracking,
+} from "./gamePlayStore";
 
 export type SelectedCategory =
 	| { type: "real"; id: number }
@@ -153,6 +157,10 @@ export interface AppState {
 	// 计时模式：playtime = 真实游戏时间（仅活跃时），elapsed = 游戏启动时间（从启动到结束）
 	timeTrackingMode: "playtime" | "elapsed";
 	setTimeTrackingMode: (mode: "playtime" | "elapsed") => void;
+
+	// 外部启动游戏自动监控（默认关闭）
+	externalLaunchMonitorEnabled: boolean;
+	setExternalLaunchMonitorEnabled: (enabled: boolean) => void;
 
 	// 更新窗口状态管理
 	showUpdateModal: boolean;
@@ -322,6 +330,17 @@ export const useStore = create<AppState>()(
 			setTimeTrackingMode: (mode: "playtime" | "elapsed") => {
 				set({ timeTrackingMode: mode });
 			},
+
+			// 外部启动游戏自动监控：默认关闭，用户在设置中显式开启
+			externalLaunchMonitorEnabled: false,
+			setExternalLaunchMonitorEnabled: (enabled: boolean) => {
+				set({ externalLaunchMonitorEnabled: enabled });
+				if (enabled) {
+					initializeExternalRunningGameScan();
+				} else {
+					disposeExternalRunningGameScan();
+				}
+			},
 			setSearchInput: (input: string) => {
 				set({ searchInput: input });
 			},
@@ -445,6 +464,9 @@ export const useStore = create<AppState>()(
 			initialize: async () => {
 				// 初始化游戏时间跟踪（数据获取由 React Query 自动触发）
 				initializeGamePlayTracking();
+				if (get().externalLaunchMonitorEnabled) {
+					initializeExternalRunningGameScan();
+				}
 
 				// 启动时同步代理设置到后端
 				const { proxyConfig } = get();
@@ -493,6 +515,8 @@ export const useStore = create<AppState>()(
 				spoilerLevel: state.spoilerLevel,
 				// 计时模式：playtime 或 elapsed
 				timeTrackingMode: state.timeTrackingMode,
+				// 外部启动游戏自动监控
+				externalLaunchMonitorEnabled: state.externalLaunchMonitorEnabled,
 				// 跳过的更新版本
 				skippedUpdateVersion: state.skippedUpdateVersion,
 				// 分组分类选择状态

--- a/src/store/gamePlayStore.ts
+++ b/src/store/gamePlayStore.ts
@@ -22,6 +22,7 @@ import { create } from "zustand";
 import { gameKeys } from "@/hooks/queries/useGames";
 import { settingsKeys } from "@/hooks/queries/useSettings";
 import { queryClient } from "@/providers/queryClient";
+import { statsService } from "@/services/invoke";
 import {
 	launchGameWithTracking,
 	stopGameWithTracking,
@@ -68,6 +69,7 @@ interface GamePlayState {
 	initTimeTracking: () => void;
 	clearActiveGame: () => void;
 	getGameRealTimeState: (gameId: number) => GameRealTimeState | null;
+	scanExternalRunningGames: () => Promise<void>;
 }
 
 /**
@@ -286,6 +288,29 @@ export const useGamePlayStore = create<GamePlayState>((set, get) => ({
 					}
 					// ====== END ======
 				},
+				// 支持外部启动游戏被后端接管时同步前端运行状态
+				(gameId: number, processId: number, startTime: number) => {
+					const timeTrackingMode = useStore.getState().timeTrackingMode;
+					set((state) => {
+						const existing = state.gameRealTimeStates[gameId];
+						const newRunningGames = new Set(state.runningGameIds);
+						newRunningGames.add(gameId);
+						return {
+							runningGameIds: newRunningGames,
+							gameRealTimeStates: {
+								...state.gameRealTimeStates,
+								[gameId]: {
+									isRunning: true,
+									currentSessionMinutes: existing?.currentSessionMinutes ?? 0,
+									currentSessionSeconds: existing?.currentSessionSeconds ?? 0,
+									startTime,
+									timeTrackingMode: existing?.timeTrackingMode ?? timeTrackingMode,
+									processId,
+								},
+							},
+						};
+					});
+				},
 			);
 
 			// 设置初始化标志
@@ -306,6 +331,42 @@ export const useGamePlayStore = create<GamePlayState>((set, get) => ({
 	/**
 	 * 清除所有运行中游戏状态
 	 */
+	scanExternalRunningGames: async () => {
+		try {
+			const timeTrackingMode = useStore.getState().timeTrackingMode;
+			const matches = await statsService.adoptExternalRunningGames(timeTrackingMode);
+			if (matches.length === 0) return;
+
+			const now = Math.floor(Date.now() / 1000);
+			set((state) => {
+				const newRunningGames = new Set(state.runningGameIds);
+				const newRealTimeStates = { ...state.gameRealTimeStates };
+				for (const match of matches) {
+					newRunningGames.add(match.game_id);
+					newRealTimeStates[match.game_id] = {
+						isRunning: true,
+						currentSessionMinutes: 0,
+						currentSessionSeconds: 0,
+						startTime: now,
+						timeTrackingMode,
+						processId: match.process_id,
+					};
+				}
+				return {
+					runningGameIds: newRunningGames,
+					gameRealTimeStates: newRealTimeStates,
+				};
+			});
+
+			await queryClient.invalidateQueries({ queryKey: gameKeys.idLists() });
+		} catch (error) {
+			console.debug(
+				"扫描外部启动游戏失败:",
+				toError(error, "Failed to scan external running games").message,
+			);
+		}
+	},
+
 	clearActiveGame: () => {
 		set({
 			runningGameIds: new Set<number>(),
@@ -320,4 +381,23 @@ export const useGamePlayStore = create<GamePlayState>((set, get) => ({
  */
 export const initializeGamePlayTracking = (): void => {
 	useGamePlayStore.getState().initTimeTracking();
+};
+
+
+let externalRunningGameScanIntervalId: number | null = null;
+
+export const initializeExternalRunningGameScan = (): void => {
+	if (externalRunningGameScanIntervalId !== null) return;
+	const runScan = () => {
+		if (!useStore.getState().externalLaunchMonitorEnabled) return;
+		void useGamePlayStore.getState().scanExternalRunningGames();
+	};
+	runScan();
+	externalRunningGameScanIntervalId = window.setInterval(runScan, 6000);
+};
+
+export const disposeExternalRunningGameScan = (): void => {
+	if (externalRunningGameScanIntervalId === null) return;
+	window.clearInterval(externalRunningGameScanIntervalId);
+	externalRunningGameScanIntervalId = null;
 };


### PR DESCRIPTION
添加在启动器启动后检查外部启动的游戏

因为需要轮询进程列表所以默认关闭

<img width="1213" height="766" alt="image" src="https://github.com/user-attachments/assets/edb77f27-545e-41f9-bb38-bff62680d663" />

并没通过Reina启动时检测外部进程来记录时间

<img width="1569" height="935" alt="image" src="https://github.com/user-attachments/assets/6e6865cb-2d37-4efb-926a-5f48c3eeb623" />
