### PR TITLE
feat(install): replace Takanawa with in-house reina-download engine

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -48,6 +48,7 @@ dependencies = [
  "xz2",
  "zbus",
  "zbus_systemd",
+ "zip 8.6.0",
 ]
 
 [[package]]
@@ -6065,7 +6066,7 @@ dependencies = [
  "tokio",
  "url",
  "windows-sys 0.60.2",
- "zip",
+ "zip 4.6.1",
 ]
 
 [[package]]
@@ -6647,6 +6648,12 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
 
 [[package]]
 name = "typeid"
@@ -8097,6 +8104,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "8.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
+dependencies = [
+ "crc32fast",
+ "flate2",
+ "indexmap 2.14.1",
+ "memchr",
+ "typed-path",
+ "zopfli",
+]
+
+[[package]]
 name = "zlib-rs"
 version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8107,6 +8128,18 @@ name = "zmij"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
 
 [[package]]
 name = "zstd"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -17,16 +17,14 @@ dependencies = [
  "migration",
  "parking_lot",
  "pinyin",
+ "reina-download",
  "reina-path",
- "reqwest 0.13.4",
  "sea-orm",
  "serde",
  "serde_json",
  "sevenz-rust2",
  "sha2 0.11.0",
  "steamlocate",
- "takanawa-core",
- "takanawa-http",
  "tar",
  "tauri",
  "tauri-build",
@@ -997,7 +995,7 @@ dependencies = [
  "bitflags 2.13.1",
  "core-foundation 0.10.1",
  "core-graphics-types",
- "foreign-types 0.5.0",
+ "foreign-types",
  "libc",
 ]
 
@@ -1767,21 +1765,12 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared 0.1.1",
-]
-
-[[package]]
-name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared 0.3.1",
+ "foreign-types-shared",
 ]
 
 [[package]]
@@ -1797,12 +1786,6 @@ dependencies = [
 
 [[package]]
 name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
-name = "foreign-types-shared"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
@@ -1814,16 +1797,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
-]
-
-[[package]]
-name = "fs2"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
-dependencies = [
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -2453,22 +2426,6 @@ dependencies = [
  "tokio-rustls",
  "tower-service",
  "webpki-roots",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
 ]
 
 [[package]]
@@ -3293,23 +3250,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "ndk"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3663,47 +3603,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "openssl"
-version = "0.10.81"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
-dependencies = [
- "bitflags 2.13.1",
- "cfg-if",
- "foreign-types 0.3.2",
- "libc",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.117"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "option-ext"
@@ -4413,6 +4316,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "reina-download"
+version = "0.1.0"
+dependencies = [
+ "httpdate",
+ "log",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "tokio-util",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "reina-path"
 version = "0.1.0"
 dependencies = [
@@ -4475,11 +4393,9 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "rustls",
@@ -4489,7 +4405,6 @@ dependencies = [
  "serde_json",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower",
@@ -5727,30 +5642,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "takanawa-core"
-version = "0.8.3"
-source = "git+https://github.com/huoshen80/takanawa.git?rev=0a895b9#0a895b98476be131ff87288e27961a41d99b1795"
-dependencies = [
- "crc32fast",
- "fs2",
- "sha2 0.11.0",
- "thiserror 2.0.20",
-]
-
-[[package]]
-name = "takanawa-http"
-version = "0.8.3"
-source = "git+https://github.com/huoshen80/takanawa.git?rev=0a895b9#0a895b98476be131ff87288e27961a41d99b1795"
-dependencies = [
- "bytes",
- "futures-util",
- "httpdate",
- "reqwest 0.13.4",
- "takanawa-core",
- "tokio",
-]
-
-[[package]]
 name = "tao"
 version = "0.35.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6452,7 +6343,9 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
@@ -6467,16 +6360,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.4",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["reina-path", "migration"]
+members = ["reina-path", "migration", "reina-download"]
 
 [package]
 name = "ReinaManager"
@@ -68,15 +68,7 @@ chrono = { version = "0.4.45", default-features = false, features = ["clock"] }
 parking_lot = "0.12.5"
 sha2 = "0.11.0"
 blake3 = "1.8.7"
-takanawa-core = { git = "https://github.com/huoshen80/takanawa.git", rev = "0a895b9" }
-takanawa-http = { git = "https://github.com/huoshen80/takanawa.git", rev = "0a895b9", default-features = false, features = [
-    "tls-platform-native",
-] }
-takanawa-reqwest = { package = "reqwest", version = "0.13.4", default-features = false, features = [
-    "native-tls",
-    "socks",
-    "system-proxy",
-] }
+reina-download = { path = "reina-download" }
 
 # Async runtime / DB
 tokio = { version = "1.53.1", features = ["rt-multi-thread", "time", "sync", "fs", "io-util", "net"] }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -25,6 +25,7 @@ sha2 = "0.11.0"
 tar = "0.4.46"
 ureq = { version = "3.4.0", default-features = false, features = ["rustls"] }
 xz2 = "0.1.7"
+zip = { version = "8.6.0", default-features = false, features = ["deflate"] }
 
 [dependencies]
 # Serialization & logging

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -13,16 +13,22 @@ const SEVEN_ZIP_SIGNATURE: &[u8] = b"7z\xBC\xAF'\x1C";
 enum PackageFormat {
     WindowsInstaller,
     TarXz,
+    Zip,
 }
 
 struct SevenZipPackage {
     platform: &'static str,
+    // Windows 使用带 zstd 编解码器的 7-Zip-zstd 分支（Shionlib 上存在 zstd
+    // 压制的 7z 包），Linux/macOS 分支无对应产物，维持官方构建。
+    version: &'static str,
     file_name: &'static str,
     url: &'static str,
     sha256: &'static str,
     executable: &'static str,
     required_library: Option<&'static str>,
     format: PackageFormat,
+    /// 压缩包内不含许可证时，从该地址下载（url, sha256）。
+    license_download: Option<(&'static str, &'static str)>,
 }
 
 fn main() {
@@ -83,6 +89,7 @@ fn prepare_seven_zip_files(
     match package.format {
         PackageFormat::WindowsInstaller => extract_windows_installer(&archive_path, &extracted)?,
         PackageFormat::TarXz => extract_tar_xz(&archive_path, &extracted)?,
+        PackageFormat::Zip => extract_zip(&archive_path, &extracted)?,
     }
 
     remove_directory_if_exists(resource_root)?;
@@ -93,18 +100,25 @@ fn prepare_seven_zip_files(
     if let Some(library) = package.required_library {
         copy_extracted_file(&extracted, library, resource_root)?;
     }
-    copy_license(&extracted, resource_root)?;
+    match package.license_download {
+        Some((url, sha256)) => {
+            let license_path = resource_root.join("License.txt");
+            download_file(url, &license_path)?;
+            verify_sha256(&license_path, sha256)?;
+        }
+        None => copy_license(&extracted, resource_root)?,
+    }
     fs::write(
         resource_root.join("NOTICE.md"),
         format!(
-            "7-Zip {SEVEN_ZIP_VERSION} is bundled at build time.\nSource: {}\nLicense: see License.txt.\n",
-            package.url
+            "7-Zip {} is bundled at build time.\nSource: {}\nLicense: see License.txt.\n",
+            package.version, package.url
         ),
     )
     .map_err(|error| format!("写入 7-Zip NOTICE 失败: {error}"))?;
     fs::write(
         resource_root.join(".build-info"),
-        format!("{SEVEN_ZIP_VERSION}\n{}\n", package.platform),
+        format!("{}\n{}\n", package.version, package.platform),
     )
     .map_err(|error| format!("写入 7-Zip 构建标记失败: {error}"))?;
     ensure_executable_permission(&resource_root.join(package.executable))
@@ -112,42 +126,51 @@ fn prepare_seven_zip_files(
 
 fn current_seven_zip_package() -> Result<&'static SevenZipPackage, String> {
     static WINDOWS_X64: SevenZipPackage = SevenZipPackage {
+        version: "26.02-zstd-v1.5.7-R2",
         platform: "windows-x64",
-        file_name: "7z2602-x64.exe",
-        url: "https://github.com/ip7z/7zip/releases/download/26.02/7z2602-x64.exe",
-        sha256: "6745fa76dc2ea031596d8678f6f6b99c3c1b435b4164a63485adbbc7b8d82ef0",
+        file_name: "7z26.02-zstd-x64.exe",
+        url: "https://github.com/mcmilk/7-Zip-zstd/releases/download/v26.02-v1.5.7-R2/7z26.02-zstd-x64.exe",
+        sha256: "22dc4608d911d7c831437b969db66a42d0477cd3f5d93987cae9f59774857fc1",
         executable: "7z.exe",
         required_library: Some("7z.dll"),
         format: PackageFormat::WindowsInstaller,
+        license_download: None,
     };
     static WINDOWS_X86: SevenZipPackage = SevenZipPackage {
+        version: "26.02-zstd-v1.5.7-R2",
         platform: "windows-x86",
-        file_name: "7z2602.exe",
-        url: "https://github.com/ip7z/7zip/releases/download/26.02/7z2602.exe",
-        sha256: "17d894c17b04984b6ffcc1b31926b39c42d315cd861c3adbf7f34bd941d529ac",
+        file_name: "7z26.02-zstd-x86.exe",
+        url: "https://github.com/mcmilk/7-Zip-zstd/releases/download/v26.02-v1.5.7-R2/7z26.02-zstd-x86.exe",
+        sha256: "9d509425fdbea2a85b77beaa246dfb63a71c0ac70dd443cf2ed3cddcf1b4992d",
         executable: "7z.exe",
         required_library: Some("7z.dll"),
         format: PackageFormat::WindowsInstaller,
+        license_download: None,
     };
     static WINDOWS_ARM64: SevenZipPackage = SevenZipPackage {
+        version: "26.02-zstd-v1.5.7-R2",
         platform: "windows-arm64",
-        file_name: "7z2602-arm64.exe",
-        url: "https://github.com/ip7z/7zip/releases/download/26.02/7z2602-arm64.exe",
-        sha256: "7c6fde79ed5e11b81c7bb6573b7962d3b6322aa5fce69c33ed19f672b55173ab",
+        file_name: "7z26.02-zstd-arm64.exe",
+        url: "https://github.com/mcmilk/7-Zip-zstd/releases/download/v26.02-v1.5.7-R2/7z26.02-zstd-arm64.exe",
+        sha256: "9749af751056e203286175527e906acc1ad0ed7b0ccc1a22de05141d77170961",
         executable: "7z.exe",
         required_library: Some("7z.dll"),
         format: PackageFormat::WindowsInstaller,
+        license_download: None,
     };
     static LINUX_X64: SevenZipPackage = SevenZipPackage {
+        version: "26.02-zstd-v1.5.7-R2",
         platform: "linux-x64",
-        file_name: "7z2602-linux-x64.tar.xz",
-        url: "https://github.com/ip7z/7zip/releases/download/26.02/7z2602-linux-x64.tar.xz",
-        sha256: "41aaba7b1235304ab5aa0624530c67ae829496cd29e875925271efdccc28c03e",
+        file_name: "linux-gcc-x64.zip",
+        url: "https://github.com/mcmilk/7-Zip-zstd/releases/download/v26.02-v1.5.7-R2/linux-gcc-x64.zip",
+        sha256: "be246e5a284d3b5e738bad5cbb24c2662996ddb9776e09575b5099ab53fa0ba3",
         executable: "7zz",
         required_library: None,
-        format: PackageFormat::TarXz,
+        format: PackageFormat::Zip,
+        license_download: Some(("https://raw.githubusercontent.com/mcmilk/7-Zip-zstd/v26.02-v1.5.7-R2/DOC/License.txt", "5b565f1591a5872cb163a17a06725c4ec010f60401c9068d1b5e1e8c89517f39")),
     };
     static LINUX_X86: SevenZipPackage = SevenZipPackage {
+        version: "26.02",
         platform: "linux-x86",
         file_name: "7z2602-linux-x86.tar.xz",
         url: "https://github.com/ip7z/7zip/releases/download/26.02/7z2602-linux-x86.tar.xz",
@@ -155,17 +178,21 @@ fn current_seven_zip_package() -> Result<&'static SevenZipPackage, String> {
         executable: "7zz",
         required_library: None,
         format: PackageFormat::TarXz,
+        license_download: None,
     };
     static LINUX_ARM64: SevenZipPackage = SevenZipPackage {
+        version: "26.02-zstd-v1.5.7-R2",
         platform: "linux-arm64",
-        file_name: "7z2602-linux-arm64.tar.xz",
-        url: "https://github.com/ip7z/7zip/releases/download/26.02/7z2602-linux-arm64.tar.xz",
-        sha256: "70ea6cc737ae1495ea2d7eb20ef3120fe579bd3f1a83a9d2362b62ec5bde2bba",
+        file_name: "linux-gcc-arm64.zip",
+        url: "https://github.com/mcmilk/7-Zip-zstd/releases/download/v26.02-v1.5.7-R2/linux-gcc-arm64.zip",
+        sha256: "64511f6ebc32d5257a535b33b21a5b6712c72aa91e28524f41e1ce92e803c909",
         executable: "7zz",
         required_library: None,
-        format: PackageFormat::TarXz,
+        format: PackageFormat::Zip,
+        license_download: Some(("https://raw.githubusercontent.com/mcmilk/7-Zip-zstd/v26.02-v1.5.7-R2/DOC/License.txt", "5b565f1591a5872cb163a17a06725c4ec010f60401c9068d1b5e1e8c89517f39")),
     };
     static MACOS_X64: SevenZipPackage = SevenZipPackage {
+        version: "26.02",
         platform: "macos-x64",
         file_name: "7z2602-mac.tar.xz",
         url: "https://github.com/ip7z/7zip/releases/download/26.02/7z2602-mac.tar.xz",
@@ -173,8 +200,10 @@ fn current_seven_zip_package() -> Result<&'static SevenZipPackage, String> {
         executable: "7zz",
         required_library: None,
         format: PackageFormat::TarXz,
+        license_download: None,
     };
     static MACOS_ARM64: SevenZipPackage = SevenZipPackage {
+        version: "26.02",
         platform: "macos-arm64",
         file_name: "7z2602-mac.tar.xz",
         url: "https://github.com/ip7z/7zip/releases/download/26.02/7z2602-mac.tar.xz",
@@ -182,6 +211,7 @@ fn current_seven_zip_package() -> Result<&'static SevenZipPackage, String> {
         executable: "7zz",
         required_library: None,
         format: PackageFormat::TarXz,
+        license_download: None,
     };
 
     let target_os = env::var("CARGO_CFG_TARGET_OS")
@@ -205,7 +235,7 @@ fn current_seven_zip_package() -> Result<&'static SevenZipPackage, String> {
 }
 
 fn seven_zip_is_cached(resource_root: &Path, package: &SevenZipPackage, executable: &Path) -> bool {
-    let build_info = format!("{SEVEN_ZIP_VERSION}\n{}\n", package.platform);
+    let build_info = format!("{}\n{}\n", package.version, package.platform);
     let library_exists = package
         .required_library
         .is_none_or(|library| resource_root.join(library).is_file());
@@ -306,6 +336,15 @@ fn extract_tar_xz(archive: &Path, destination: &Path) -> Result<(), String> {
     let decoder = xz2::read::XzDecoder::new(BufReader::new(file));
     tar::Archive::new(decoder)
         .unpack(destination)
+        .map_err(|error| format!("解压 7-Zip 压缩包失败: {error}"))
+}
+
+fn extract_zip(archive: &Path, destination: &Path) -> Result<(), String> {
+    fs::create_dir_all(destination).map_err(|error| format!("创建 7-Zip 解压目录失败: {error}"))?;
+    let file = File::open(archive).map_err(|error| format!("读取 7-Zip 压缩包失败: {error}"))?;
+    let mut zip = zip::ZipArchive::new(BufReader::new(file))
+        .map_err(|error| format!("解析 7-Zip 压缩包失败: {error}"))?;
+    zip.extract(destination)
         .map_err(|error| format!("解压 7-Zip 压缩包失败: {error}"))
 }
 

--- a/src-tauri/reina-download/Cargo.toml
+++ b/src-tauri/reina-download/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "reina-download"
+version = "0.1.0"
+edition = "2024"
+rust-version = "1.85"
+publish = false
+description = "Segmented, resumable HTTP downloader used by ReinaManager's install pipeline"
+
+[dependencies]
+httpdate = "1.0"
+log = "0.4"
+reqwest = { version = "0.12", default-features = false }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tokio = { version = "1", features = ["rt", "sync", "time", "macros"] }
+tokio-util = "0.7"
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = [
+    "Win32_Foundation",
+    "Win32_System_IO",
+    "Win32_System_Ioctl",
+] }
+
+[dev-dependencies]
+tempfile = "3"
+tokio = { version = "1", features = ["full"] }

--- a/src-tauri/reina-download/src/control.rs
+++ b/src-tauri/reina-download/src/control.rs
@@ -1,8 +1,7 @@
-//! On-disk control file that records per-piece progress.
+//! 记录分片进度的磁盘控制文件。
 //!
-//! The control file sits next to the target file and is written atomically
-//! (temp file + rename). Its presence means the target is incomplete; the
-//! downloader removes it as the last step of a successful download.
+//! 控制文件位于目标文件旁，原子写入（临时文件 + rename）。它的存在表示
+//! 目标未完成；下载成功的最后一步就是删掉它。
 
 use std::ffi::OsString;
 use std::io;
@@ -12,11 +11,11 @@ use serde::{Deserialize, Serialize};
 
 use crate::fsx::atomic_write;
 
-/// File name suffix appended to the target path for the control file.
+/// 控制文件名后缀，拼接在目标路径之后。
 pub const CONTROL_SUFFIX: &str = ".reina-dl";
 pub(crate) const CONTROL_VERSION: u32 = 1;
 
-/// Returns the control file path for a target file.
+/// 返回目标文件对应的控制文件路径。
 #[must_use]
 pub fn control_path(target: &Path) -> PathBuf {
     let mut value: OsString = target.as_os_str().to_owned();
@@ -24,8 +23,7 @@ pub fn control_path(target: &Path) -> PathBuf {
     PathBuf::from(value)
 }
 
-/// Returns every path the downloader may create for a target, including the
-/// target itself. Callers use this to clean up a discarded download.
+/// 返回下载器可能创建的所有路径（含目标本身），供调用方清理废弃下载。
 #[must_use]
 pub fn artifact_paths(target: &Path) -> Vec<PathBuf> {
     let control = control_path(target);
@@ -60,7 +58,7 @@ pub(crate) struct ControlFile {
     pub etag: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_modified: Option<String>,
-    /// Bytes written contiguously from the start of each piece.
+    /// 每个分片从起点开始连续已写入的字节数。
     pub pieces: Vec<u64>,
 }
 
@@ -84,8 +82,8 @@ impl ControlFile {
         }
     }
 
-    /// Loads the control file. `Ok(None)` means it does not exist. A corrupt
-    /// file is reported as `InvalidData`; callers treat that as "start over".
+    /// 加载控制文件。`Ok(None)` 表示不存在；文件损坏报 `InvalidData`，
+    /// 调用方按重新开始处理。
     pub(crate) fn load(path: &Path) -> io::Result<Option<Self>> {
         let bytes = match std::fs::read(path) {
             Ok(bytes) => bytes,

--- a/src-tauri/reina-download/src/control.rs
+++ b/src-tauri/reina-download/src/control.rs
@@ -1,0 +1,198 @@
+//! On-disk control file that records per-piece progress.
+//!
+//! The control file sits next to the target file and is written atomically
+//! (temp file + rename). Its presence means the target is incomplete; the
+//! downloader removes it as the last step of a successful download.
+
+use std::ffi::OsString;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::fsx::atomic_write;
+
+/// File name suffix appended to the target path for the control file.
+pub const CONTROL_SUFFIX: &str = ".reina-dl";
+pub(crate) const CONTROL_VERSION: u32 = 1;
+
+/// Returns the control file path for a target file.
+#[must_use]
+pub fn control_path(target: &Path) -> PathBuf {
+    let mut value: OsString = target.as_os_str().to_owned();
+    value.push(CONTROL_SUFFIX);
+    PathBuf::from(value)
+}
+
+/// Returns every path the downloader may create for a target, including the
+/// target itself. Callers use this to clean up a discarded download.
+#[must_use]
+pub fn artifact_paths(target: &Path) -> Vec<PathBuf> {
+    let control = control_path(target);
+    let mut temp: OsString = control.as_os_str().to_owned();
+    temp.push(".tmp");
+    vec![target.to_path_buf(), control, PathBuf::from(temp)]
+}
+
+#[must_use]
+pub(crate) fn piece_count(size: u64, piece_size: u64) -> u64 {
+    if size == 0 {
+        0
+    } else {
+        size.div_ceil(piece_size)
+    }
+}
+
+#[must_use]
+pub(crate) fn piece_len(size: u64, piece_size: u64, index: u64) -> u64 {
+    let start = index * piece_size;
+    (size - start).min(piece_size)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct ControlFile {
+    pub version: u32,
+    pub size: u64,
+    pub piece_size: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub identity: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub etag: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_modified: Option<String>,
+    /// Bytes written contiguously from the start of each piece.
+    pub pieces: Vec<u64>,
+}
+
+impl ControlFile {
+    pub(crate) fn new(
+        size: u64,
+        piece_size: u64,
+        identity: Option<String>,
+        etag: Option<String>,
+        last_modified: Option<String>,
+    ) -> Self {
+        let count = piece_count(size, piece_size);
+        Self {
+            version: CONTROL_VERSION,
+            size,
+            piece_size,
+            identity,
+            etag,
+            last_modified,
+            pieces: vec![0; usize::try_from(count).unwrap_or(usize::MAX)],
+        }
+    }
+
+    /// Loads the control file. `Ok(None)` means it does not exist. A corrupt
+    /// file is reported as `InvalidData`; callers treat that as "start over".
+    pub(crate) fn load(path: &Path) -> io::Result<Option<Self>> {
+        let bytes = match std::fs::read(path) {
+            Ok(bytes) => bytes,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
+            Err(error) => return Err(error),
+        };
+        let parsed: Self = serde_json::from_slice(&bytes)
+            .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error.to_string()))?;
+        parsed
+            .validate()
+            .map_err(|detail| io::Error::new(io::ErrorKind::InvalidData, detail))?;
+        Ok(Some(parsed))
+    }
+
+    pub(crate) fn save(&self, path: &Path) -> io::Result<()> {
+        let bytes =
+            serde_json::to_vec(self).map_err(|error| io::Error::other(error.to_string()))?;
+        atomic_write(path, &bytes)
+    }
+
+    pub(crate) fn validate(&self) -> Result<(), String> {
+        if self.version != CONTROL_VERSION {
+            return Err(format!("unsupported control file version {}", self.version));
+        }
+        if self.piece_size == 0 {
+            return Err("piece size must be positive".to_owned());
+        }
+        let expected = piece_count(self.size, self.piece_size);
+        if u64::try_from(self.pieces.len()).ok() != Some(expected) {
+            return Err(format!(
+                "piece count mismatch: expected {expected}, found {}",
+                self.pieces.len()
+            ));
+        }
+        for (index, written) in self.pieces.iter().enumerate() {
+            let len = piece_len(self.size, self.piece_size, index as u64);
+            if *written > len {
+                return Err(format!("piece {index} claims {written} bytes of {len}"));
+            }
+        }
+        Ok(())
+    }
+
+    #[must_use]
+    pub(crate) fn written_total(&self) -> u64 {
+        self.pieces.iter().sum()
+    }
+
+    #[must_use]
+    pub(crate) fn is_complete(&self) -> bool {
+        self.pieces
+            .iter()
+            .enumerate()
+            .all(|(index, written)| *written == piece_len(self.size, self.piece_size, index as u64))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn piece_geometry() {
+        assert_eq!(piece_count(0, 4), 0);
+        assert_eq!(piece_count(10, 4), 3);
+        assert_eq!(piece_len(10, 4, 0), 4);
+        assert_eq!(piece_len(10, 4, 2), 2);
+        assert_eq!(piece_count(8, 4), 2);
+        assert_eq!(piece_len(8, 4, 1), 4);
+    }
+
+    #[test]
+    fn control_round_trip_and_validation() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("game.7z.reina-dl");
+        let mut control = ControlFile::new(10, 4, Some("sha256:ab".into()), None, None);
+        control.pieces[0] = 4;
+        control.pieces[2] = 1;
+        control.save(&path).unwrap();
+
+        let loaded = ControlFile::load(&path).unwrap().unwrap();
+        assert_eq!(loaded, control);
+        assert_eq!(loaded.written_total(), 5);
+        assert!(!loaded.is_complete());
+
+        std::fs::write(
+            &path,
+            b"{\"version\":1,\"size\":10,\"piece_size\":4,\"pieces\":[9,0,0]}",
+        )
+        .unwrap();
+        let error = ControlFile::load(&path).unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+
+        std::fs::write(&path, b"not json").unwrap();
+        assert!(ControlFile::load(&path).is_err());
+        assert!(
+            ControlFile::load(&dir.path().join("missing"))
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn artifact_paths_cover_control_and_temp() {
+        let paths = artifact_paths(Path::new("/tmp/game.7z"));
+        assert_eq!(paths[0], Path::new("/tmp/game.7z"));
+        assert_eq!(paths[1], Path::new("/tmp/game.7z.reina-dl"));
+        assert_eq!(paths[2], Path::new("/tmp/game.7z.reina-dl.tmp"));
+    }
+}

--- a/src-tauri/reina-download/src/engine.rs
+++ b/src-tauri/reina-download/src/engine.rs
@@ -1,0 +1,898 @@
+//! Download orchestration: probe, piece scheduling, committer, finalize.
+
+use std::collections::VecDeque;
+use std::fs::File;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant, SystemTime};
+
+use reqwest::header::{ETAG, LAST_MODIFIED, RANGE};
+use reqwest::{Client, StatusCode};
+use tokio::sync::watch;
+use tokio::task::JoinSet;
+use tokio_util::sync::CancellationToken;
+
+use crate::control::{ControlFile, control_path, piece_len};
+use crate::error::{DownloadError, map_reqwest};
+use crate::fsx;
+use crate::http;
+use crate::limiter::{Adaptive, Gate};
+use crate::progress::{Phase, Progress, Shared};
+use crate::types::{DownloadOptions, DownloadRequest, Outcome};
+
+const BASE_BACKOFF: Duration = Duration::from_millis(500);
+const MAX_BACKOFF: Duration = Duration::from_secs(30);
+
+/// Downloads `request.url` into `request.target`, resuming from the control
+/// file when one is present. See the crate documentation for the contract.
+///
+/// # Errors
+///
+/// Returns a [`DownloadError`] describing the first unrecoverable failure.
+/// Cancellation is reported as `Ok(Outcome::Cancelled)`, never as an error.
+pub async fn download(
+    request: DownloadRequest,
+    options: DownloadOptions,
+    client: Client,
+    progress: watch::Sender<Progress>,
+    cancel: CancellationToken,
+) -> Result<Outcome, DownloadError> {
+    options.validate()?;
+    let control_file_path = control_path(&request.target);
+
+    // A target without a control file is either an already-finished download
+    // or a foreign file we must not touch. A corrupt control file still counts
+    // as "a download was in progress": start that download over.
+    let control_file_exists = control_file_path.exists();
+    let existing_control = match ControlFile::load(&control_file_path) {
+        Ok(existing) => existing,
+        Err(error) => {
+            log::warn!("discarding unreadable control file: {error}");
+            None
+        }
+    };
+    if !control_file_exists {
+        if let Ok(metadata) = std::fs::metadata(&request.target) {
+            if metadata.len() == request.expected_size {
+                return Ok(Outcome::Completed);
+            }
+            return Err(DownloadError::TargetConflict(request.target.clone()));
+        }
+    }
+
+    let shared = Arc::new(Shared::new());
+    shared.set_total(request.expected_size);
+    let emitter = spawn_emitter(
+        Arc::clone(&shared),
+        progress.clone(),
+        options.progress_interval,
+    );
+    let result = run(
+        &request,
+        &options,
+        &client,
+        Arc::clone(&shared),
+        existing_control,
+        &control_file_path,
+        &cancel,
+    )
+    .await;
+
+    match &result {
+        Ok(Outcome::Completed) => shared.set_phase(Phase::Done),
+        Ok(Outcome::Cancelled) => shared.set_phase(Phase::Cancelled),
+        Err(_) => {}
+    }
+    emitter.abort();
+    let _ = progress.send(shared.snapshot(0.0));
+    result
+}
+
+#[allow(clippy::too_many_lines)]
+async fn run(
+    request: &DownloadRequest,
+    options: &DownloadOptions,
+    client: &Client,
+    shared: Arc<Shared>,
+    existing_control: Option<ControlFile>,
+    control_file_path: &std::path::Path,
+    cancel: &CancellationToken,
+) -> Result<Outcome, DownloadError> {
+    // Probe.
+    shared.set_phase(Phase::Probing);
+    let probe = tokio::select! {
+        biased;
+        () = cancel.cancelled() => return Ok(Outcome::Cancelled),
+        probe = probe_with_retry(client, &request.url, options, &shared) => probe?,
+    };
+    if let Some(total) = probe.total {
+        if total != request.expected_size {
+            return Err(DownloadError::SizeMismatch {
+                expected: request.expected_size,
+                actual: total,
+            });
+        }
+    }
+    let size = request.expected_size;
+
+    // Reconcile any previous state with what the server now reports.
+    let mut control = reconcile(existing_control, request, &probe, options.piece_size, size);
+    if !probe.range_supported {
+        // A server that ignores ranges cannot resume a partial file.
+        control.pieces.iter_mut().for_each(|written| *written = 0);
+    }
+
+    // Open the target and persist the control file before the first byte, so
+    // "target present, control absent" always means a finished download.
+    let target_path = request.target.clone();
+    let file = tokio::task::spawn_blocking(move || fsx::open_target(&target_path, size, true))
+        .await
+        .map_err(join_error)??;
+    let file = Arc::new(file);
+    control.save(control_file_path)?;
+
+    let pieces: Arc<Vec<AtomicU64>> = Arc::new(
+        control
+            .pieces
+            .iter()
+            .map(|written| AtomicU64::new(*written))
+            .collect(),
+    );
+    let already = control.written_total();
+    shared.written.store(already, Ordering::Relaxed);
+    shared.committed.store(already, Ordering::Relaxed);
+
+    if size == 0 || control.is_complete() {
+        return finalize(&shared, &file, control_file_path)
+            .await
+            .map(|()| Outcome::Completed);
+    }
+
+    let committer = Committer {
+        file: Arc::clone(&file),
+        pieces: Arc::clone(&pieces),
+        template: control,
+        path: control_file_path.to_path_buf(),
+        shared: Arc::clone(&shared),
+    };
+    let committer_task =
+        spawn_committer(committer.clone(), options.commit_interval, cancel.clone());
+
+    let outcome = if probe.range_supported {
+        shared.set_phase(Phase::Downloading);
+        run_segmented(
+            request, options, client, &shared, &pieces, &file, size, cancel,
+        )
+        .await
+    } else {
+        shared.set_phase(Phase::SingleStream);
+        run_single_stream(
+            request, options, client, &shared, &pieces, &file, size, cancel,
+        )
+        .await
+    };
+
+    // Stop the periodic committer, then always take one final durable commit so
+    // pause/cancel/errors never lose more than the page cache.
+    committer_task.abort();
+    let _ = committer_task.await;
+    let commit_result = committer.commit().await;
+
+    match outcome {
+        Ok(Outcome::Completed) => {
+            commit_result?;
+            finalize(&shared, &file, control_file_path).await?;
+            Ok(Outcome::Completed)
+        }
+        Ok(Outcome::Cancelled) => {
+            commit_result?;
+            Ok(Outcome::Cancelled)
+        }
+        Err(error) => Err(error),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Probe
+
+#[derive(Debug, Clone)]
+struct ProbeResult {
+    total: Option<u64>,
+    range_supported: bool,
+    etag: Option<String>,
+    last_modified: Option<String>,
+}
+
+/// Retries the probe on retryable failures (429, 5xx, transport errors) with
+/// the same backoff policy as piece requests.
+async fn probe_with_retry(
+    client: &Client,
+    url: &str,
+    options: &DownloadOptions,
+    shared: &Arc<Shared>,
+) -> Result<ProbeResult, DownloadError> {
+    const PROBE_ATTEMPTS: u32 = 5;
+    let mut attempt = 0u32;
+    loop {
+        match probe(client, url).await {
+            Ok(result) => return Ok(result),
+            Err(error) if error.is_retryable() && attempt + 1 < PROBE_ATTEMPTS => {
+                attempt += 1;
+                shared.retries.fetch_add(1, Ordering::Relaxed);
+                log::debug!("probe attempt {attempt} failed, retrying: {error}");
+                tokio::time::sleep(backoff(attempt).min(options.stall_timeout)).await;
+            }
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+async fn probe(client: &Client, url: &str) -> Result<ProbeResult, DownloadError> {
+    let response = client
+        .get(url)
+        .header(RANGE, "bytes=0-0")
+        .send()
+        .await
+        .map_err(|error| map_reqwest(&error))?;
+    let status = response.status();
+    let headers = response.headers().clone();
+    let etag = http::header_string(&headers, ETAG);
+    let last_modified = http::header_string(&headers, LAST_MODIFIED);
+
+    if status == StatusCode::PARTIAL_CONTENT {
+        http::ensure_identity(&headers)?;
+        let range = http::content_range(&headers)?
+            .ok_or_else(|| DownloadError::Protocol("206 without Content-Range".into()))?;
+        return Ok(ProbeResult {
+            total: range.total,
+            range_supported: true,
+            etag,
+            last_modified,
+        });
+    }
+    if status == StatusCode::OK {
+        // Server ignored the range: fall back to a single stream.
+        http::ensure_identity(&headers)?;
+        let total = http::content_length(&headers)?;
+        return Ok(ProbeResult {
+            total,
+            range_supported: false,
+            etag,
+            last_modified,
+        });
+    }
+    if status == StatusCode::RANGE_NOT_SATISFIABLE {
+        let value = headers
+            .get(reqwest::header::CONTENT_RANGE)
+            .and_then(|value| value.to_str().ok())
+            .ok_or_else(|| DownloadError::Protocol("416 without Content-Range".into()))?;
+        let total = http::parse_unsatisfied_total(value)?;
+        return Ok(ProbeResult {
+            total: Some(total),
+            range_supported: true,
+            etag,
+            last_modified,
+        });
+    }
+    Err(http::status_error(status))
+}
+
+fn reconcile(
+    existing: Option<ControlFile>,
+    request: &DownloadRequest,
+    probe: &ProbeResult,
+    piece_size: u64,
+    size: u64,
+) -> ControlFile {
+    let fresh = || {
+        ControlFile::new(
+            size,
+            piece_size,
+            request.identity.clone(),
+            probe.etag.clone(),
+            probe.last_modified.clone(),
+        )
+    };
+    let Some(control) = existing else {
+        return fresh();
+    };
+    if control.size != size || control.piece_size != piece_size {
+        log::info!("discarding control file: geometry changed");
+        return fresh();
+    }
+    if let (Some(ours), Some(theirs)) = (&request.identity, &control.identity) {
+        if ours == theirs {
+            // Same declared content: validator drift (CDN edges disagreeing on
+            // ETag) is tolerated because the caller verifies the final hash.
+            return control;
+        }
+        log::info!("discarding control file: content identity changed");
+        return fresh();
+    }
+    // No checksum to fall back on: validators are the only safety net.
+    let etag_matches = match (&control.etag, &probe.etag) {
+        (Some(stored), Some(current)) => stored == current,
+        _ => true,
+    };
+    let modified_matches = match (&control.last_modified, &probe.last_modified) {
+        (Some(stored), Some(current)) => stored == current,
+        _ => true,
+    };
+    if etag_matches && modified_matches {
+        control
+    } else {
+        log::info!("discarding control file: remote validators changed");
+        fresh()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Segmented mode
+
+struct WorkerReport {
+    index: u64,
+    attempt: u32,
+    result: Result<(), WorkerFail>,
+}
+
+struct WorkerFail {
+    error: DownloadError,
+    rate_limited: bool,
+    retry_after: Option<Duration>,
+    attempt_started: Instant,
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn run_segmented(
+    request: &DownloadRequest,
+    options: &DownloadOptions,
+    client: &Client,
+    shared: &Arc<Shared>,
+    pieces: &Arc<Vec<AtomicU64>>,
+    file: &Arc<File>,
+    size: u64,
+    cancel: &CancellationToken,
+) -> Result<Outcome, DownloadError> {
+    let adaptive = Arc::new(Adaptive::new(
+        options.min_connections,
+        options.clamped_initial(),
+        options.max_connections,
+        options.grow_after_successes,
+    ));
+    let budget: Option<Gate> = options.budget.as_ref().map(|budget| budget.0.clone());
+    let mut pending: VecDeque<(u64, u32)> = (0..pieces.len() as u64)
+        .filter(|index| {
+            pieces[usize::try_from(*index).expect("piece index fits usize")].load(Ordering::Relaxed)
+                < piece_len(size, options.piece_size, *index)
+        })
+        .map(|index| (index, 0))
+        .collect();
+    let mut tasks: JoinSet<WorkerReport> = JoinSet::new();
+    let mut consecutive_failures = 0u32;
+
+    let outcome = loop {
+        if cancel.is_cancelled() {
+            break Ok(Outcome::Cancelled);
+        }
+        while tasks.len() < adaptive.current() {
+            let Some((index, attempt)) = pending.pop_front() else {
+                break;
+            };
+            tasks.spawn(piece_worker(
+                client.clone(),
+                request.url.clone(),
+                Arc::clone(file),
+                Arc::clone(pieces),
+                Arc::clone(shared),
+                Arc::clone(&adaptive),
+                budget.clone(),
+                cancel.clone(),
+                options.piece_size,
+                size,
+                index,
+                attempt,
+                options.stall_timeout,
+            ));
+        }
+        shared.connections.store(tasks.len(), Ordering::Relaxed);
+        if tasks.is_empty() {
+            if pending.is_empty() {
+                break Ok(Outcome::Completed);
+            }
+            // Target shrank below queued work between iterations; yield briefly.
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            continue;
+        }
+
+        let joined = tokio::select! {
+            biased;
+            () = cancel.cancelled() => break Ok(Outcome::Cancelled),
+            joined = tasks.join_next() => joined,
+        };
+        let Some(joined) = joined else { continue };
+        let report = joined.map_err(join_error)?;
+        match report.result {
+            Ok(()) => {
+                adaptive.on_success();
+                consecutive_failures = 0;
+            }
+            Err(fail) => {
+                if !fail.error.is_retryable() {
+                    break Err(fail.error);
+                }
+                shared.retries.fetch_add(1, Ordering::Relaxed);
+                consecutive_failures += 1;
+                if consecutive_failures > options.max_consecutive_failures {
+                    break Err(DownloadError::RetriesExhausted {
+                        attempts: consecutive_failures,
+                        last: Box::new(fail.error),
+                    });
+                }
+                if fail.rate_limited {
+                    adaptive.on_rate_limited(
+                        fail.attempt_started,
+                        fail.retry_after.unwrap_or(BASE_BACKOFF),
+                    );
+                } else {
+                    log::debug!(
+                        "piece {} attempt {} failed, requeueing: {}",
+                        report.index,
+                        report.attempt + 1,
+                        fail.error
+                    );
+                }
+                pending.push_back((report.index, report.attempt + 1));
+            }
+        }
+    };
+
+    tasks.shutdown().await;
+    outcome
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn piece_worker(
+    client: Client,
+    url: String,
+    file: Arc<File>,
+    pieces: Arc<Vec<AtomicU64>>,
+    shared: Arc<Shared>,
+    adaptive: Arc<Adaptive>,
+    budget: Option<Gate>,
+    cancel: CancellationToken,
+    piece_size: u64,
+    size: u64,
+    index: u64,
+    attempt: u32,
+    stall_timeout: Duration,
+) -> WorkerReport {
+    let report = |result| WorkerReport {
+        index,
+        attempt,
+        result,
+    };
+    let cancelled = || {
+        report(Err(WorkerFail {
+            error: DownloadError::Network("cancelled".into()),
+            rate_limited: false,
+            retry_after: None,
+            attempt_started: Instant::now(),
+        }))
+    };
+
+    // Backoff for retries, then any shared rate-limit pause, then the budget.
+    let delay = backoff(attempt).max(adaptive.remaining_pause());
+    if !delay.is_zero() {
+        tokio::select! {
+            biased;
+            () = cancel.cancelled() => return cancelled(),
+            () = tokio::time::sleep(delay) => {}
+        }
+    }
+    let _permit = match &budget {
+        Some(gate) => match gate.acquire(&cancel).await {
+            Some(permit) => Some(permit),
+            None => return cancelled(),
+        },
+        None => None,
+    };
+
+    let attempt_started = Instant::now();
+    let result = fetch_piece(
+        &client,
+        &url,
+        &file,
+        &pieces,
+        &shared,
+        &cancel,
+        piece_size,
+        size,
+        index,
+        stall_timeout,
+        attempt_started,
+    )
+    .await;
+    report(result)
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn fetch_piece(
+    client: &Client,
+    url: &str,
+    file: &Arc<File>,
+    pieces: &Arc<Vec<AtomicU64>>,
+    shared: &Arc<Shared>,
+    cancel: &CancellationToken,
+    piece_size: u64,
+    size: u64,
+    index: u64,
+    stall_timeout: Duration,
+    attempt_started: Instant,
+) -> Result<(), WorkerFail> {
+    let fail = |error: DownloadError, rate_limited, retry_after| WorkerFail {
+        error,
+        rate_limited,
+        retry_after,
+        attempt_started,
+    };
+    let plain = |error: DownloadError| fail(error, false, None);
+
+    let slot = &pieces[usize::try_from(index).expect("piece index fits usize")];
+    let piece_start = index * piece_size;
+    let len = piece_len(size, piece_size, index);
+    let already = slot.load(Ordering::Relaxed);
+    if already >= len {
+        return Ok(());
+    }
+    let range_start = piece_start + already;
+    let range_end = piece_start + len - 1;
+
+    let response = client
+        .get(url)
+        .header(RANGE, format!("bytes={range_start}-{range_end}"))
+        .send()
+        .await
+        .map_err(|error| plain(map_reqwest(&error)))?;
+    let status = response.status();
+    if status != StatusCode::PARTIAL_CONTENT {
+        let retry_after = http::retry_after(response.headers(), SystemTime::now());
+        let error = if status == StatusCode::OK {
+            DownloadError::Protocol("server stopped honoring range requests".into())
+        } else {
+            http::status_error(status)
+        };
+        let rate_limited = status == StatusCode::TOO_MANY_REQUESTS;
+        return Err(fail(error, rate_limited, retry_after));
+    }
+    http::ensure_identity(response.headers()).map_err(&plain)?;
+    let range = http::content_range(response.headers())
+        .map_err(&plain)?
+        .ok_or_else(|| plain(DownloadError::Protocol("206 without Content-Range".into())))?;
+    if range.start != range_start || range.end != range_end {
+        return Err(plain(DownloadError::Protocol(format!(
+            "Content-Range mismatch: asked {range_start}-{range_end}, got {}-{}",
+            range.start, range.end
+        ))));
+    }
+    if let Some(length) = http::content_length(response.headers()).map_err(&plain)? {
+        if length != len - already {
+            return Err(plain(DownloadError::Protocol(format!(
+                "Content-Length mismatch for piece {index}: expected {}, got {length}",
+                len - already
+            ))));
+        }
+    }
+
+    let mut response = response;
+    let mut written = already;
+    loop {
+        if cancel.is_cancelled() {
+            // Report as retryable network interruption; the outer loop sees the
+            // token and stops before requeueing.
+            return Err(plain(DownloadError::Network("cancelled".into())));
+        }
+        let chunk = tokio::select! {
+            biased;
+            () = cancel.cancelled() => return Err(plain(DownloadError::Network("cancelled".into()))),
+            chunk = tokio::time::timeout(stall_timeout, response.chunk()) => match chunk {
+                Err(_) => {
+                    return Err(plain(DownloadError::Network(format!(
+                        "no data for {} s on piece {index}",
+                        stall_timeout.as_secs()
+                    ))));
+                }
+                Ok(result) => result.map_err(|error| plain(map_reqwest(&error)))?,
+            },
+        };
+        let Some(chunk) = chunk else { break };
+        if chunk.is_empty() {
+            continue;
+        }
+        let chunk_len = chunk.len() as u64;
+        if written + chunk_len > len {
+            return Err(plain(DownloadError::Protocol(format!(
+                "piece {index} body exceeded {len} bytes"
+            ))));
+        }
+        let offset = piece_start + written;
+        let write_file = Arc::clone(file);
+        tokio::task::spawn_blocking(move || fsx::write_all_at(&write_file, offset, &chunk))
+            .await
+            .map_err(|error| plain(join_error(error)))?
+            .map_err(|error| plain(DownloadError::Disk(error)))?;
+        written += chunk_len;
+        slot.store(written, Ordering::Relaxed);
+        shared.written.fetch_add(chunk_len, Ordering::Relaxed);
+    }
+    if written != len {
+        return Err(plain(DownloadError::Network(format!(
+            "piece {index} ended early: {written} of {len} bytes"
+        ))));
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Single-stream fallback
+
+#[allow(clippy::too_many_arguments)]
+async fn run_single_stream(
+    request: &DownloadRequest,
+    options: &DownloadOptions,
+    client: &Client,
+    shared: &Arc<Shared>,
+    pieces: &Arc<Vec<AtomicU64>>,
+    file: &Arc<File>,
+    size: u64,
+    cancel: &CancellationToken,
+) -> Result<Outcome, DownloadError> {
+    shared.connections.store(1, Ordering::Relaxed);
+    let mut attempt = 0u32;
+    loop {
+        if cancel.is_cancelled() {
+            return Ok(Outcome::Cancelled);
+        }
+        if attempt > 0 {
+            let delay = backoff(attempt);
+            tokio::select! {
+                biased;
+                () = cancel.cancelled() => return Ok(Outcome::Cancelled),
+                () = tokio::time::sleep(delay) => {}
+            }
+        }
+        match stream_once(request, options, client, shared, pieces, file, size, cancel).await {
+            Ok(true) => return Ok(Outcome::Completed),
+            Ok(false) => return Ok(Outcome::Cancelled),
+            Err(error) if error.is_retryable() => {
+                shared.retries.fetch_add(1, Ordering::Relaxed);
+                attempt += 1;
+                if attempt > options.max_consecutive_failures {
+                    return Err(DownloadError::RetriesExhausted {
+                        attempts: attempt,
+                        last: Box::new(error),
+                    });
+                }
+                // Restart from zero: the server does not honor ranges.
+                for slot in pieces.iter() {
+                    slot.store(0, Ordering::Relaxed);
+                }
+                shared.written.store(0, Ordering::Relaxed);
+                log::warn!("single-stream download restarting (attempt {attempt}): {error}");
+            }
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+/// One full pass. `Ok(true)` = complete, `Ok(false)` = cancelled.
+#[allow(clippy::too_many_arguments)]
+async fn stream_once(
+    request: &DownloadRequest,
+    options: &DownloadOptions,
+    client: &Client,
+    shared: &Arc<Shared>,
+    pieces: &Arc<Vec<AtomicU64>>,
+    file: &Arc<File>,
+    size: u64,
+    cancel: &CancellationToken,
+) -> Result<bool, DownloadError> {
+    let response = client
+        .get(&request.url)
+        .send()
+        .await
+        .map_err(|error| map_reqwest(&error))?;
+    let status = response.status();
+    if status != StatusCode::OK {
+        return Err(http::status_error(status));
+    }
+    http::ensure_identity(response.headers())?;
+    if let Some(length) = http::content_length(response.headers())? {
+        if length != size {
+            return Err(DownloadError::SizeMismatch {
+                expected: size,
+                actual: length,
+            });
+        }
+    }
+
+    let mut response = response;
+    let mut absolute = 0u64;
+    loop {
+        let chunk = tokio::select! {
+            biased;
+            () = cancel.cancelled() => return Ok(false),
+            chunk = tokio::time::timeout(options.stall_timeout, response.chunk()) => match chunk {
+                Err(_) => return Err(DownloadError::Network("single stream stalled".into())),
+                Ok(result) => result.map_err(|error| map_reqwest(&error))?,
+            },
+        };
+        let Some(chunk) = chunk else { break };
+        if chunk.is_empty() {
+            continue;
+        }
+        let chunk_len = chunk.len() as u64;
+        if absolute + chunk_len > size {
+            return Err(DownloadError::Protocol(
+                "body exceeded expected size".into(),
+            ));
+        }
+        let offset = absolute;
+        let write_file = Arc::clone(file);
+        tokio::task::spawn_blocking(move || fsx::write_all_at(&write_file, offset, &chunk))
+            .await
+            .map_err(join_error)?
+            .map_err(DownloadError::Disk)?;
+        absolute += chunk_len;
+        shared.written.store(absolute, Ordering::Relaxed);
+        // Contiguous progress: fill every fully or partially covered piece.
+        let mut cursor = absolute;
+        for (index, slot) in pieces.iter().enumerate() {
+            let len = piece_len(size, options.piece_size, index as u64);
+            let value = cursor.min(len);
+            slot.store(value, Ordering::Relaxed);
+            cursor -= value;
+            if cursor == 0 {
+                break;
+            }
+        }
+    }
+    if absolute != size {
+        return Err(DownloadError::Network(format!(
+            "single stream ended early: {absolute} of {size} bytes"
+        )));
+    }
+    Ok(true)
+}
+
+// ---------------------------------------------------------------------------
+// Committer, finalize, emitter
+
+#[derive(Clone)]
+struct Committer {
+    file: Arc<File>,
+    pieces: Arc<Vec<AtomicU64>>,
+    template: ControlFile,
+    path: std::path::PathBuf,
+    shared: Arc<Shared>,
+}
+
+impl Committer {
+    /// Snapshot piece counters, make the data durable, then record the
+    /// snapshot. Ordering guarantees the control file never over-claims.
+    async fn commit(&self) -> Result<(), DownloadError> {
+        let snapshot: Vec<u64> = self
+            .pieces
+            .iter()
+            .map(|slot| slot.load(Ordering::Relaxed))
+            .collect();
+        let total: u64 = snapshot.iter().sum();
+        let mut control = self.template.clone();
+        control.pieces = snapshot;
+        let file = Arc::clone(&self.file);
+        let path = self.path.clone();
+        tokio::task::spawn_blocking(move || -> std::io::Result<()> {
+            file.sync_data()?;
+            control.save(&path)
+        })
+        .await
+        .map_err(join_error)?
+        .map_err(DownloadError::Disk)?;
+        self.shared.committed.store(total, Ordering::Relaxed);
+        Ok(())
+    }
+}
+
+fn spawn_committer(
+    committer: Committer,
+    interval: Duration,
+    cancel: CancellationToken,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(interval.max(Duration::from_millis(100)));
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        ticker.tick().await; // first tick is immediate; skip it
+        loop {
+            tokio::select! {
+                biased;
+                () = cancel.cancelled() => break,
+                _ = ticker.tick() => {
+                    if let Err(error) = committer.commit().await {
+                        log::warn!("periodic commit failed: {error}");
+                    }
+                }
+            }
+        }
+    })
+}
+
+async fn finalize(
+    shared: &Arc<Shared>,
+    file: &Arc<File>,
+    control_file_path: &std::path::Path,
+) -> Result<(), DownloadError> {
+    shared.set_phase(Phase::Finalizing);
+    let file = Arc::clone(file);
+    tokio::task::spawn_blocking(move || file.sync_all())
+        .await
+        .map_err(join_error)?
+        .map_err(DownloadError::Disk)?;
+    fsx::remove_if_exists(control_file_path)?;
+    Ok(())
+}
+
+fn spawn_emitter(
+    shared: Arc<Shared>,
+    sender: watch::Sender<Progress>,
+    interval: Duration,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(interval.max(Duration::from_millis(50)));
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        let mut previous_written = shared.written.load(Ordering::Relaxed);
+        let mut previous_at = Instant::now();
+        let mut smoothed = 0.0f64;
+        loop {
+            ticker.tick().await;
+            let written = shared.written.load(Ordering::Relaxed);
+            let now = Instant::now();
+            let elapsed = now.saturating_duration_since(previous_at).as_secs_f64();
+            if elapsed > 0.0 {
+                let instant_speed = written.saturating_sub(previous_written) as f64 / elapsed;
+                smoothed = if smoothed == 0.0 {
+                    instant_speed
+                } else {
+                    0.3 * instant_speed + 0.7 * smoothed
+                };
+            }
+            previous_written = written;
+            previous_at = now;
+            let _ = sender.send(shared.snapshot(smoothed));
+        }
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+
+fn backoff(attempt: u32) -> Duration {
+    if attempt == 0 {
+        return Duration::ZERO;
+    }
+    let exponent = attempt.saturating_sub(1).min(6);
+    let base = BASE_BACKOFF.saturating_mul(1 << exponent).min(MAX_BACKOFF);
+    // Cheap jitter without a rand dependency: sub-millisecond clock noise.
+    let jitter_ms = u64::from(
+        (std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|value| value.subsec_nanos())
+            .unwrap_or(0))
+            % 250,
+    );
+    base + Duration::from_millis(jitter_ms)
+}
+
+fn join_error(error: tokio::task::JoinError) -> DownloadError {
+    DownloadError::Disk(std::io::Error::other(format!(
+        "worker task failed: {error}"
+    )))
+}

--- a/src-tauri/reina-download/src/engine.rs
+++ b/src-tauri/reina-download/src/engine.rs
@@ -3,7 +3,7 @@
 use std::collections::VecDeque;
 use std::fs::File;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::{Duration, Instant, SystemTime};
 
 use reqwest::header::{ETAG, LAST_MODIFIED, RANGE};
@@ -160,10 +160,22 @@ async fn run(
         .await
     } else {
         shared.set_phase(Phase::SingleStream);
-        run_single_stream(
+        match run_single_stream(
             request, options, client, &shared, &pieces, &file, size, cancel,
         )
         .await
+        {
+            Ok(StreamEnd::Upgraded) => {
+                shared.set_phase(Phase::Downloading);
+                run_segmented(
+                    request, options, client, &shared, &pieces, &file, size, cancel,
+                )
+                .await
+            }
+            Ok(StreamEnd::Completed) => Ok(Outcome::Completed),
+            Ok(StreamEnd::Cancelled) => Ok(Outcome::Cancelled),
+            Err(error) => Err(error),
+        }
     };
 
     // 停掉周期提交器后必做一次最终落盘提交，暂停/取消/出错最多损失页缓存。
@@ -625,6 +637,13 @@ async fn fetch_piece(
 // ---------------------------------------------------------------------------
 // 单流回退
 
+enum StreamEnd {
+    Completed,
+    Cancelled,
+    /// 探测到服务器已支持 Range，应切换到分段模式继续。
+    Upgraded,
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn run_single_stream(
     request: &DownloadRequest,
@@ -635,24 +654,61 @@ async fn run_single_stream(
     file: &Arc<File>,
     size: u64,
     cancel: &CancellationToken,
-) -> Result<Outcome, DownloadError> {
+) -> Result<StreamEnd, DownloadError> {
     shared.connections.store(1, Ordering::Relaxed);
+    // 后台定期重探 Range 支持；单流进度按分片记录，升级时可无损衔接。
+    let upgrade = Arc::new(AtomicBool::new(false));
+    let prober = spawn_upgrade_prober(
+        client.clone(),
+        request.url.clone(),
+        options.upgrade_probe_interval,
+        cancel.clone(),
+        Arc::clone(&upgrade),
+    );
+    let end = run_single_stream_inner(
+        request, options, client, shared, pieces, file, size, cancel, &upgrade,
+    )
+    .await;
+    prober.abort();
+    end
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn run_single_stream_inner(
+    request: &DownloadRequest,
+    options: &DownloadOptions,
+    client: &Client,
+    shared: &Arc<Shared>,
+    pieces: &Arc<Vec<AtomicU64>>,
+    file: &Arc<File>,
+    size: u64,
+    cancel: &CancellationToken,
+    upgrade: &Arc<AtomicBool>,
+) -> Result<StreamEnd, DownloadError> {
     let mut attempt = 0u32;
     loop {
         if cancel.is_cancelled() {
-            return Ok(Outcome::Cancelled);
+            return Ok(StreamEnd::Cancelled);
+        }
+        if upgrade.load(Ordering::Relaxed) {
+            return Ok(StreamEnd::Upgraded);
         }
         if attempt > 0 {
             let delay = backoff(attempt);
             tokio::select! {
                 biased;
-                () = cancel.cancelled() => return Ok(Outcome::Cancelled),
+                () = cancel.cancelled() => return Ok(StreamEnd::Cancelled),
                 () = tokio::time::sleep(delay) => {}
             }
         }
-        match stream_once(request, options, client, shared, pieces, file, size, cancel).await {
-            Ok(true) => return Ok(Outcome::Completed),
-            Ok(false) => return Ok(Outcome::Cancelled),
+        match stream_once(
+            request, options, client, shared, pieces, file, size, cancel, upgrade,
+        )
+        .await
+        {
+            Ok(StreamPass::Complete) => return Ok(StreamEnd::Completed),
+            Ok(StreamPass::Cancelled) => return Ok(StreamEnd::Cancelled),
+            Ok(StreamPass::Upgrade) => return Ok(StreamEnd::Upgraded),
             Err(error) if error.is_retryable() => {
                 shared.retries.fetch_add(1, Ordering::Relaxed);
                 attempt += 1;
@@ -661,6 +717,10 @@ async fn run_single_stream(
                         attempts: attempt,
                         last: Box::new(error),
                     });
+                }
+                // 已支持 Range 就不必从零重来，直接升级续传。
+                if upgrade.load(Ordering::Relaxed) {
+                    return Ok(StreamEnd::Upgraded);
                 }
                 // 从零重来：服务器不认 Range。
                 for slot in pieces.iter() {
@@ -674,7 +734,13 @@ async fn run_single_stream(
     }
 }
 
-/// 完整跑一遍。`Ok(true)` 完成，`Ok(false)` 被取消。
+enum StreamPass {
+    Complete,
+    Cancelled,
+    Upgrade,
+}
+
+/// 完整跑一遍单流下载。
 #[allow(clippy::too_many_arguments)]
 async fn stream_once(
     request: &DownloadRequest,
@@ -685,7 +751,8 @@ async fn stream_once(
     file: &Arc<File>,
     size: u64,
     cancel: &CancellationToken,
-) -> Result<bool, DownloadError> {
+    upgrade: &Arc<AtomicBool>,
+) -> Result<StreamPass, DownloadError> {
     let response = client
         .get(&request.url)
         .send()
@@ -710,7 +777,7 @@ async fn stream_once(
     loop {
         let chunk = tokio::select! {
             biased;
-            () = cancel.cancelled() => return Ok(false),
+            () = cancel.cancelled() => return Ok(StreamPass::Cancelled),
             chunk = tokio::time::timeout(options.stall_timeout, response.chunk()) => match chunk {
                 Err(_) => return Err(DownloadError::Network("single stream stalled".into())),
                 Ok(result) => result.map_err(|error| map_reqwest(&error))?,
@@ -745,13 +812,43 @@ async fn stream_once(
                 break;
             }
         }
+        // 写入之后再检查升级信号，保证已收字节都计入进度。
+        if upgrade.load(Ordering::Relaxed) {
+            return Ok(StreamPass::Upgrade);
+        }
     }
     if absolute != size {
         return Err(DownloadError::Network(format!(
             "single stream ended early: {absolute} of {size} bytes"
         )));
     }
-    Ok(true)
+    Ok(StreamPass::Complete)
+}
+
+/// 单流期间的后台探测：服务器一旦返回 206 就置位升级标志。
+fn spawn_upgrade_prober(
+    client: Client,
+    url: String,
+    interval: Duration,
+    cancel: CancellationToken,
+    upgrade: Arc<AtomicBool>,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let interval = interval.max(Duration::from_millis(100));
+        loop {
+            tokio::select! {
+                biased;
+                () = cancel.cancelled() => break,
+                () = tokio::time::sleep(interval) => {}
+            }
+            if let Ok(result) = probe(&client, &url).await {
+                if result.range_supported {
+                    upgrade.store(true, Ordering::Relaxed);
+                    break;
+                }
+            }
+        }
+    })
 }
 
 // ---------------------------------------------------------------------------

--- a/src-tauri/reina-download/src/engine.rs
+++ b/src-tauri/reina-download/src/engine.rs
@@ -168,8 +168,14 @@ async fn run(
         path: control_file_path.to_path_buf(),
         shared: Arc::clone(&shared),
     };
-    let committer_task =
-        spawn_committer(committer.clone(), options.commit_interval, cancel.clone());
+    // 提交器不能被 abort：进入阻塞线程池的 fsync/写控制文件无法取消，会与
+    // 最终提交并发写同一个临时文件。用独立信号让它在两次提交之间自行退出。
+    let committer_shutdown = CancellationToken::new();
+    let committer_task = spawn_committer(
+        committer.clone(),
+        options.commit_interval,
+        committer_shutdown.clone(),
+    );
 
     let outcome = if probe.range_supported {
         shared.set_phase(Phase::Downloading);
@@ -198,7 +204,7 @@ async fn run(
     };
 
     // 停掉周期提交器后必做一次最终落盘提交，暂停/取消/出错最多损失页缓存。
-    committer_task.abort();
+    committer_shutdown.cancel();
     let _ = committer_task.await;
     let commit_result = committer.commit().await;
 
@@ -913,7 +919,7 @@ impl Committer {
 fn spawn_committer(
     committer: Committer,
     interval: Duration,
-    cancel: CancellationToken,
+    shutdown: CancellationToken,
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         let mut ticker = tokio::time::interval(interval.max(Duration::from_millis(100)));
@@ -922,12 +928,12 @@ fn spawn_committer(
         loop {
             tokio::select! {
                 biased;
-                () = cancel.cancelled() => break,
-                _ = ticker.tick() => {
-                    if let Err(error) = committer.commit().await {
-                        log::warn!("periodic commit failed: {error}");
-                    }
-                }
+                () = shutdown.cancelled() => break,
+                _ = ticker.tick() => {}
+            }
+            // 提交放在 select 之外：一旦开始就完整跑完，停止信号只在间隙生效。
+            if let Err(error) = committer.commit().await {
+                log::warn!("periodic commit failed: {error}");
             }
         }
     })

--- a/src-tauri/reina-download/src/engine.rs
+++ b/src-tauri/reina-download/src/engine.rs
@@ -1,4 +1,4 @@
-//! Download orchestration: probe, piece scheduling, committer, finalize.
+//! 下载编排：探测、分片调度、提交器、收尾。
 
 use std::collections::VecDeque;
 use std::fs::File;
@@ -23,13 +23,9 @@ use crate::types::{DownloadOptions, DownloadRequest, Outcome};
 const BASE_BACKOFF: Duration = Duration::from_millis(500);
 const MAX_BACKOFF: Duration = Duration::from_secs(30);
 
-/// Downloads `request.url` into `request.target`, resuming from the control
-/// file when one is present. See the crate documentation for the contract.
+/// 把 `request.url` 下载到 `request.target`，存在控制文件时自动续传。
 ///
-/// # Errors
-///
-/// Returns a [`DownloadError`] describing the first unrecoverable failure.
-/// Cancellation is reported as `Ok(Outcome::Cancelled)`, never as an error.
+/// 取消以 `Ok(Outcome::Cancelled)` 返回，不算错误；契约详见 crate 文档。
 pub async fn download(
     request: DownloadRequest,
     options: DownloadOptions,
@@ -40,9 +36,8 @@ pub async fn download(
     options.validate()?;
     let control_file_path = control_path(&request.target);
 
-    // A target without a control file is either an already-finished download
-    // or a foreign file we must not touch. A corrupt control file still counts
-    // as "a download was in progress": start that download over.
+    // 无控制文件的目标要么是已完成的下载，要么是不能动的外来文件；
+    // 控制文件损坏仍算"下载进行过"，直接重新开始。
     let control_file_exists = control_file_path.exists();
     let existing_control = match ControlFile::load(&control_file_path) {
         Ok(existing) => existing,
@@ -98,7 +93,7 @@ async fn run(
     control_file_path: &std::path::Path,
     cancel: &CancellationToken,
 ) -> Result<Outcome, DownloadError> {
-    // Probe.
+    // 探测。
     shared.set_phase(Phase::Probing);
     let probe = tokio::select! {
         biased;
@@ -115,15 +110,14 @@ async fn run(
     }
     let size = request.expected_size;
 
-    // Reconcile any previous state with what the server now reports.
+    // 用服务器当前报告的信息核对既有状态。
     let mut control = reconcile(existing_control, request, &probe, options.piece_size, size);
     if !probe.range_supported {
-        // A server that ignores ranges cannot resume a partial file.
+        // 忽略 Range 的服务器无法续传半成品。
         control.pieces.iter_mut().for_each(|written| *written = 0);
     }
 
-    // Open the target and persist the control file before the first byte, so
-    // "target present, control absent" always means a finished download.
+    // 先建目标文件并落控制文件再收字节，保证"有目标无控制文件"恒等于下载完成。
     let target_path = request.target.clone();
     let file = tokio::task::spawn_blocking(move || fsx::open_target(&target_path, size, true))
         .await
@@ -172,8 +166,7 @@ async fn run(
         .await
     };
 
-    // Stop the periodic committer, then always take one final durable commit so
-    // pause/cancel/errors never lose more than the page cache.
+    // 停掉周期提交器后必做一次最终落盘提交，暂停/取消/出错最多损失页缓存。
     committer_task.abort();
     let _ = committer_task.await;
     let commit_result = committer.commit().await;
@@ -193,7 +186,7 @@ async fn run(
 }
 
 // ---------------------------------------------------------------------------
-// Probe
+// 探测
 
 #[derive(Debug, Clone)]
 struct ProbeResult {
@@ -203,8 +196,7 @@ struct ProbeResult {
     last_modified: Option<String>,
 }
 
-/// Retries the probe on retryable failures (429, 5xx, transport errors) with
-/// the same backoff policy as piece requests.
+/// 探测失败可重试（429、5xx、传输错误）时按与分片一致的退避策略重试。
 async fn probe_with_retry(
     client: &Client,
     url: &str,
@@ -251,7 +243,7 @@ async fn probe(client: &Client, url: &str) -> Result<ProbeResult, DownloadError>
         });
     }
     if status == StatusCode::OK {
-        // Server ignored the range: fall back to a single stream.
+        // 服务器忽略了 Range：回退单流。
         http::ensure_identity(&headers)?;
         let total = http::content_length(&headers)?;
         return Ok(ProbeResult {
@@ -302,14 +294,13 @@ fn reconcile(
     }
     if let (Some(ours), Some(theirs)) = (&request.identity, &control.identity) {
         if ours == theirs {
-            // Same declared content: validator drift (CDN edges disagreeing on
-            // ETag) is tolerated because the caller verifies the final hash.
+            // 声明的内容一致：CDN 各节点 ETag 漂移可以容忍，最终哈希由调用方兜底。
             return control;
         }
         log::info!("discarding control file: content identity changed");
         return fresh();
     }
-    // No checksum to fall back on: validators are the only safety net.
+    // 没有校验和兜底，validators 是唯一防线。
     let etag_matches = match (&control.etag, &probe.etag) {
         (Some(stored), Some(current)) => stored == current,
         _ => true,
@@ -327,7 +318,7 @@ fn reconcile(
 }
 
 // ---------------------------------------------------------------------------
-// Segmented mode
+// 分段模式
 
 struct WorkerReport {
     index: u64,
@@ -399,7 +390,7 @@ async fn run_segmented(
             if pending.is_empty() {
                 break Ok(Outcome::Completed);
             }
-            // Target shrank below queued work between iterations; yield briefly.
+            // 目标在两次循环间缩小到低于排队量，稍等再看。
             tokio::time::sleep(Duration::from_millis(10)).await;
             continue;
         }
@@ -480,7 +471,7 @@ async fn piece_worker(
         }))
     };
 
-    // Backoff for retries, then any shared rate-limit pause, then the budget.
+    // 依次等待：重试退避、全局限流暂停、连接预算。
     let delay = backoff(attempt).max(adaptive.remaining_pause());
     if !delay.is_zero() {
         tokio::select! {
@@ -587,8 +578,7 @@ async fn fetch_piece(
     let mut written = already;
     loop {
         if cancel.is_cancelled() {
-            // Report as retryable network interruption; the outer loop sees the
-            // token and stops before requeueing.
+            // 报告为可重试的网络中断；外层循环看到取消令牌，不会真正重排。
             return Err(plain(DownloadError::Network("cancelled".into())));
         }
         let chunk = tokio::select! {
@@ -633,7 +623,7 @@ async fn fetch_piece(
 }
 
 // ---------------------------------------------------------------------------
-// Single-stream fallback
+// 单流回退
 
 #[allow(clippy::too_many_arguments)]
 async fn run_single_stream(
@@ -672,7 +662,7 @@ async fn run_single_stream(
                         last: Box::new(error),
                     });
                 }
-                // Restart from zero: the server does not honor ranges.
+                // 从零重来：服务器不认 Range。
                 for slot in pieces.iter() {
                     slot.store(0, Ordering::Relaxed);
                 }
@@ -684,7 +674,7 @@ async fn run_single_stream(
     }
 }
 
-/// One full pass. `Ok(true)` = complete, `Ok(false)` = cancelled.
+/// 完整跑一遍。`Ok(true)` 完成，`Ok(false)` 被取消。
 #[allow(clippy::too_many_arguments)]
 async fn stream_once(
     request: &DownloadRequest,
@@ -744,7 +734,7 @@ async fn stream_once(
             .map_err(DownloadError::Disk)?;
         absolute += chunk_len;
         shared.written.store(absolute, Ordering::Relaxed);
-        // Contiguous progress: fill every fully or partially covered piece.
+        // 连续进度：填充所有被覆盖的分片计数。
         let mut cursor = absolute;
         for (index, slot) in pieces.iter().enumerate() {
             let len = piece_len(size, options.piece_size, index as u64);
@@ -765,7 +755,7 @@ async fn stream_once(
 }
 
 // ---------------------------------------------------------------------------
-// Committer, finalize, emitter
+// 提交器、收尾、进度推送
 
 #[derive(Clone)]
 struct Committer {
@@ -777,8 +767,7 @@ struct Committer {
 }
 
 impl Committer {
-    /// Snapshot piece counters, make the data durable, then record the
-    /// snapshot. Ordering guarantees the control file never over-claims.
+    /// 先快照分片计数、再落盘、最后写控制文件——顺序保证控制文件永不高估。
     async fn commit(&self) -> Result<(), DownloadError> {
         let snapshot: Vec<u64> = self
             .pieces
@@ -872,7 +861,7 @@ fn spawn_emitter(
 }
 
 // ---------------------------------------------------------------------------
-// Helpers
+// 辅助
 
 fn backoff(attempt: u32) -> Duration {
     if attempt == 0 {
@@ -880,7 +869,7 @@ fn backoff(attempt: u32) -> Duration {
     }
     let exponent = attempt.saturating_sub(1).min(6);
     let base = BASE_BACKOFF.saturating_mul(1 << exponent).min(MAX_BACKOFF);
-    // Cheap jitter without a rand dependency: sub-millisecond clock noise.
+    // 用亚毫秒时钟噪声做抖动，省掉 rand 依赖。
     let jitter_ms = u64::from(
         (std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)

--- a/src-tauri/reina-download/src/engine.rs
+++ b/src-tauri/reina-download/src/engine.rs
@@ -100,6 +100,25 @@ async fn run(
         () = cancel.cancelled() => return Ok(Outcome::Cancelled),
         probe = probe_with_retry(client, &request.url, options, &shared) => probe?,
     };
+    // 部分源站只在首个请求上忽略 Range；短暂等待后复测一次，尽量避免进入单流。
+    let probe = if probe.range_supported {
+        probe
+    } else {
+        tokio::select! {
+            biased;
+            () = cancel.cancelled() => return Ok(Outcome::Cancelled),
+            () = tokio::time::sleep(options.range_confirm_delay) => {}
+        }
+        match self::probe(client, &request.url).await.ok() {
+            Some(second)
+                if second.range_supported
+                    && (probe.total.is_none() || second.total == probe.total) =>
+            {
+                second
+            }
+            _ => probe,
+        }
+    };
     if let Some(total) = probe.total {
         if total != request.expected_size {
             return Err(DownloadError::SizeMismatch {
@@ -835,12 +854,15 @@ fn spawn_upgrade_prober(
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         let interval = interval.max(Duration::from_millis(100));
+        // 源站往往很快恢复 206，首次探测提前到 2 秒内。
+        let mut delay = interval.min(Duration::from_secs(2));
         loop {
             tokio::select! {
                 biased;
                 () = cancel.cancelled() => break,
-                () = tokio::time::sleep(interval) => {}
+                () = tokio::time::sleep(delay) => {}
             }
+            delay = interval;
             if let Ok(result) = probe(&client, &url).await {
                 if result.range_supported {
                     upgrade.store(true, Ordering::Relaxed);

--- a/src-tauri/reina-download/src/error.rs
+++ b/src-tauri/reina-download/src/error.rs
@@ -1,41 +1,36 @@
 use std::fmt;
 use std::path::PathBuf;
 
-/// Errors returned by [`crate::download`].
+/// [`crate::download`] 返回的错误。
 ///
-/// Cancellation is not an error: a cancelled download returns
-/// [`crate::Outcome::Cancelled`] after persisting its state.
+/// 取消不是错误：被取消的下载在落盘后返回 [`crate::Outcome::Cancelled`]。
 #[derive(Debug)]
 pub enum DownloadError {
-    /// The server answered with a status the downloader cannot recover from,
-    /// or a retryable status whose retry budget has been exhausted.
+    /// 无法恢复的 HTTP 状态，或可重试状态耗尽了重试预算。
     Http { status: u16, retryable: bool },
-    /// The server's reported size does not match the size the caller expects.
+    /// 服务器报告的大小与调用方期望不一致。
     SizeMismatch { expected: u64, actual: u64 },
-    /// The remote resource changed identity while downloading and no checksum
-    /// was available to justify continuing.
+    /// 远端内容发生变化，且没有校验和可以兜底。
     RemoteChanged(String),
-    /// A response violated the HTTP range contract (bad `Content-Range`,
-    /// unexpected body length, compressed body, and so on).
+    /// 响应违反 Range 协议（Content-Range 错误、长度不符、被压缩等）。
     Protocol(String),
-    /// Transport failure: connect, TLS, reset, stall.
+    /// 传输层失败：连接、TLS、重置、停滞。
     Network(String),
-    /// Local filesystem failure while writing data or control state.
+    /// 写数据或控制文件时的本地磁盘错误。
     Disk(std::io::Error),
-    /// The target path already exists, is not a completed download, and there
-    /// is no control file describing it.
+    /// 目标路径已有文件，但既不是完成的下载也没有控制文件描述它。
     TargetConflict(PathBuf),
-    /// Consecutive retryable failures exceeded the configured budget.
+    /// 连续可重试失败超出配置的预算。
     RetriesExhausted {
         attempts: u32,
         last: Box<DownloadError>,
     },
-    /// The caller supplied an invalid request or option.
+    /// 调用方传入的请求或配置无效。
     InvalidConfig(String),
 }
 
 impl DownloadError {
-    /// Whether another attempt at the same operation could reasonably succeed.
+    /// 再试一次是否可能成功。
     #[must_use]
     pub fn is_retryable(&self) -> bool {
         match self {
@@ -50,8 +45,7 @@ impl DownloadError {
         }
     }
 
-    /// The HTTP status associated with this failure, looking through
-    /// [`Self::RetriesExhausted`].
+    /// 关联的 HTTP 状态码，会透过 [`Self::RetriesExhausted`] 查找。
     #[must_use]
     pub fn http_status(&self) -> Option<u16> {
         match self {
@@ -61,7 +55,7 @@ impl DownloadError {
         }
     }
 
-    /// Stable machine-readable name for logging and UI mapping.
+    /// 稳定的错误类别名，供日志与 UI 映射。
     #[must_use]
     pub fn kind(&self) -> &'static str {
         match self {

--- a/src-tauri/reina-download/src/error.rs
+++ b/src-tauri/reina-download/src/error.rs
@@ -1,0 +1,152 @@
+use std::fmt;
+use std::path::PathBuf;
+
+/// Errors returned by [`crate::download`].
+///
+/// Cancellation is not an error: a cancelled download returns
+/// [`crate::Outcome::Cancelled`] after persisting its state.
+#[derive(Debug)]
+pub enum DownloadError {
+    /// The server answered with a status the downloader cannot recover from,
+    /// or a retryable status whose retry budget has been exhausted.
+    Http { status: u16, retryable: bool },
+    /// The server's reported size does not match the size the caller expects.
+    SizeMismatch { expected: u64, actual: u64 },
+    /// The remote resource changed identity while downloading and no checksum
+    /// was available to justify continuing.
+    RemoteChanged(String),
+    /// A response violated the HTTP range contract (bad `Content-Range`,
+    /// unexpected body length, compressed body, and so on).
+    Protocol(String),
+    /// Transport failure: connect, TLS, reset, stall.
+    Network(String),
+    /// Local filesystem failure while writing data or control state.
+    Disk(std::io::Error),
+    /// The target path already exists, is not a completed download, and there
+    /// is no control file describing it.
+    TargetConflict(PathBuf),
+    /// Consecutive retryable failures exceeded the configured budget.
+    RetriesExhausted {
+        attempts: u32,
+        last: Box<DownloadError>,
+    },
+    /// The caller supplied an invalid request or option.
+    InvalidConfig(String),
+}
+
+impl DownloadError {
+    /// Whether another attempt at the same operation could reasonably succeed.
+    #[must_use]
+    pub fn is_retryable(&self) -> bool {
+        match self {
+            Self::Http { retryable, .. } => *retryable,
+            Self::Protocol(_) | Self::Network(_) => true,
+            Self::SizeMismatch { .. }
+            | Self::RemoteChanged(_)
+            | Self::Disk(_)
+            | Self::TargetConflict(_)
+            | Self::RetriesExhausted { .. }
+            | Self::InvalidConfig(_) => false,
+        }
+    }
+
+    /// The HTTP status associated with this failure, looking through
+    /// [`Self::RetriesExhausted`].
+    #[must_use]
+    pub fn http_status(&self) -> Option<u16> {
+        match self {
+            Self::Http { status, .. } => Some(*status),
+            Self::RetriesExhausted { last, .. } => last.http_status(),
+            _ => None,
+        }
+    }
+
+    /// Stable machine-readable name for logging and UI mapping.
+    #[must_use]
+    pub fn kind(&self) -> &'static str {
+        match self {
+            Self::Http { .. } => "http",
+            Self::SizeMismatch { .. } => "size_mismatch",
+            Self::RemoteChanged(_) => "remote_changed",
+            Self::Protocol(_) => "protocol",
+            Self::Network(_) => "network",
+            Self::Disk(_) => "disk",
+            Self::TargetConflict(_) => "target_conflict",
+            Self::RetriesExhausted { .. } => "retries_exhausted",
+            Self::InvalidConfig(_) => "invalid_config",
+        }
+    }
+}
+
+impl fmt::Display for DownloadError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Http { status, retryable } => {
+                if *retryable {
+                    write!(f, "retryable HTTP status {status}")
+                } else {
+                    write!(f, "HTTP status {status}")
+                }
+            }
+            Self::SizeMismatch { expected, actual } => {
+                write!(
+                    f,
+                    "size mismatch: expected {expected} bytes, server reports {actual}"
+                )
+            }
+            Self::RemoteChanged(detail) => write!(f, "remote resource changed: {detail}"),
+            Self::Protocol(detail) => write!(f, "HTTP protocol violation: {detail}"),
+            Self::Network(detail) => write!(f, "network error: {detail}"),
+            Self::Disk(error) => write!(f, "disk error: {error}"),
+            Self::TargetConflict(path) => {
+                write!(
+                    f,
+                    "target already exists without a control file: {}",
+                    path.display()
+                )
+            }
+            Self::RetriesExhausted { attempts, last } => {
+                write!(
+                    f,
+                    "gave up after {attempts} consecutive failures; last error: {last}"
+                )
+            }
+            Self::InvalidConfig(detail) => write!(f, "invalid configuration: {detail}"),
+        }
+    }
+}
+
+impl std::error::Error for DownloadError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Disk(error) => Some(error),
+            Self::RetriesExhausted { last, .. } => Some(last.as_ref()),
+            _ => None,
+        }
+    }
+}
+
+impl From<std::io::Error> for DownloadError {
+    fn from(error: std::io::Error) -> Self {
+        Self::Disk(error)
+    }
+}
+
+pub(crate) fn map_reqwest(error: &reqwest::Error) -> DownloadError {
+    if error.is_timeout() {
+        return DownloadError::Network(format!("request timed out: {error}"));
+    }
+    if error.is_connect() {
+        return DownloadError::Network(format!("connection failed: {error}"));
+    }
+    if error.is_redirect() {
+        return DownloadError::Protocol(format!("redirect policy violated: {error}"));
+    }
+    if error.is_body() || error.is_decode() {
+        return DownloadError::Network(format!("body transfer failed: {error}"));
+    }
+    if error.is_builder() || error.is_request() {
+        return DownloadError::InvalidConfig(error.to_string());
+    }
+    DownloadError::Network(error.to_string())
+}

--- a/src-tauri/reina-download/src/fsx.rs
+++ b/src-tauri/reina-download/src/fsx.rs
@@ -1,14 +1,13 @@
-//! Filesystem helpers: positioned writes, sparse preallocation, atomic replace.
+//! 文件系统辅助：定位写、稀疏预分配、原子替换。
 
 use std::ffi::OsString;
 use std::fs::{File, OpenOptions};
 use std::io;
 use std::path::{Path, PathBuf};
 
-/// Writes the whole buffer at `offset` without touching a shared cursor.
+/// 在 `offset` 处写入整个缓冲区，不动共享游标。
 ///
-/// Safe to call concurrently from several threads on the same `File` as long
-/// as the ranges do not overlap.
+/// 只要范围不重叠，多线程对同一 `File` 并发调用是安全的。
 pub(crate) fn write_all_at(file: &File, offset: u64, buf: &[u8]) -> io::Result<()> {
     let mut written = 0usize;
     while written < buf.len() {
@@ -40,10 +39,9 @@ fn write_at(file: &File, offset: u64, buf: &[u8]) -> io::Result<usize> {
     file.seek_write(buf, offset)
 }
 
-/// Opens (or creates) the target file and reserves `size` bytes.
+/// 打开（或创建）目标文件并预留 `size` 字节。
 ///
-/// On Windows the file is marked sparse first so that reserving space does not
-/// force NTFS to zero-fill the whole file on the first write near the end.
+/// Windows 上先标记稀疏，避免 NTFS 在靠后位置首次写入时同步填零整个文件。
 pub(crate) fn open_target(path: &Path, size: u64, preallocate: bool) -> io::Result<File> {
     let file = OpenOptions::new()
         .read(true)
@@ -67,8 +65,8 @@ fn mark_sparse(file: &File) -> io::Result<()> {
     use windows_sys::Win32::System::Ioctl::FSCTL_SET_SPARSE;
 
     let mut returned: u32 = 0;
-    // SAFETY: the handle is valid for the lifetime of `file`; no in/out buffers
-    // are passed and `returned` outlives the call.
+    // SAFETY: 句柄在 `file` 存活期内有效；无输入输出缓冲区，
+    // `returned` 存活到调用结束。
     let ok = unsafe {
         DeviceIoControl(
             file.as_raw_handle() as _,
@@ -92,8 +90,7 @@ fn mark_sparse(_file: &File) -> io::Result<()> {
     Ok(())
 }
 
-/// Writes `bytes` to `path` by way of a temporary sibling and a rename, so a
-/// crash never leaves a half-written file behind.
+/// 先写临时文件再 rename，崩溃不会留下半写的文件。
 pub(crate) fn atomic_write(path: &Path, bytes: &[u8]) -> io::Result<()> {
     let temp = temp_path(path);
     {
@@ -114,7 +111,7 @@ fn temp_path(path: &Path) -> PathBuf {
     PathBuf::from(value)
 }
 
-/// Removes a file, treating "not found" as success.
+/// 删除文件，不存在视为成功。
 pub(crate) fn remove_if_exists(path: &Path) -> io::Result<()> {
     match std::fs::remove_file(path) {
         Ok(()) => Ok(()),

--- a/src-tauri/reina-download/src/fsx.rs
+++ b/src-tauri/reina-download/src/fsx.rs
@@ -1,0 +1,150 @@
+//! Filesystem helpers: positioned writes, sparse preallocation, atomic replace.
+
+use std::ffi::OsString;
+use std::fs::{File, OpenOptions};
+use std::io;
+use std::path::{Path, PathBuf};
+
+/// Writes the whole buffer at `offset` without touching a shared cursor.
+///
+/// Safe to call concurrently from several threads on the same `File` as long
+/// as the ranges do not overlap.
+pub(crate) fn write_all_at(file: &File, offset: u64, buf: &[u8]) -> io::Result<()> {
+    let mut written = 0usize;
+    while written < buf.len() {
+        let position = offset + written as u64;
+        match write_at(file, position, &buf[written..]) {
+            Ok(0) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::WriteZero,
+                    "positioned write returned zero bytes",
+                ));
+            }
+            Ok(n) => written += n,
+            Err(error) if error.kind() == io::ErrorKind::Interrupted => continue,
+            Err(error) => return Err(error),
+        }
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn write_at(file: &File, offset: u64, buf: &[u8]) -> io::Result<usize> {
+    use std::os::unix::fs::FileExt;
+    file.write_at(buf, offset)
+}
+
+#[cfg(windows)]
+fn write_at(file: &File, offset: u64, buf: &[u8]) -> io::Result<usize> {
+    use std::os::windows::fs::FileExt;
+    file.seek_write(buf, offset)
+}
+
+/// Opens (or creates) the target file and reserves `size` bytes.
+///
+/// On Windows the file is marked sparse first so that reserving space does not
+/// force NTFS to zero-fill the whole file on the first write near the end.
+pub(crate) fn open_target(path: &Path, size: u64, preallocate: bool) -> io::Result<File> {
+    let file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(path)?;
+    if let Err(error) = mark_sparse(&file) {
+        log::debug!("could not mark {} sparse: {error}", path.display());
+    }
+    if preallocate && file.metadata()?.len() != size {
+        file.set_len(size)?;
+    }
+    Ok(file)
+}
+
+#[cfg(windows)]
+fn mark_sparse(file: &File) -> io::Result<()> {
+    use std::os::windows::io::AsRawHandle;
+    use windows_sys::Win32::System::IO::DeviceIoControl;
+    use windows_sys::Win32::System::Ioctl::FSCTL_SET_SPARSE;
+
+    let mut returned: u32 = 0;
+    // SAFETY: the handle is valid for the lifetime of `file`; no in/out buffers
+    // are passed and `returned` outlives the call.
+    let ok = unsafe {
+        DeviceIoControl(
+            file.as_raw_handle() as _,
+            FSCTL_SET_SPARSE,
+            std::ptr::null(),
+            0,
+            std::ptr::null_mut(),
+            0,
+            &mut returned,
+            std::ptr::null_mut(),
+        )
+    };
+    if ok == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+#[cfg(not(windows))]
+fn mark_sparse(_file: &File) -> io::Result<()> {
+    Ok(())
+}
+
+/// Writes `bytes` to `path` by way of a temporary sibling and a rename, so a
+/// crash never leaves a half-written file behind.
+pub(crate) fn atomic_write(path: &Path, bytes: &[u8]) -> io::Result<()> {
+    let temp = temp_path(path);
+    {
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(&temp)?;
+        io::Write::write_all(&mut file, bytes)?;
+        file.sync_all()?;
+    }
+    std::fs::rename(&temp, path)
+}
+
+fn temp_path(path: &Path) -> PathBuf {
+    let mut value: OsString = path.as_os_str().to_owned();
+    value.push(".tmp");
+    PathBuf::from(value)
+}
+
+/// Removes a file, treating "not found" as success.
+pub(crate) fn remove_if_exists(path: &Path) -> io::Result<()> {
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn positioned_writes_do_not_interfere() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("out.bin");
+        let file = open_target(&path, 8, true).unwrap();
+        write_all_at(&file, 4, b"wxyz").unwrap();
+        write_all_at(&file, 0, b"abcd").unwrap();
+        drop(file);
+        assert_eq!(std::fs::read(&path).unwrap(), b"abcdwxyz");
+    }
+
+    #[test]
+    fn atomic_write_replaces_existing() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("control.json");
+        atomic_write(&path, b"one").unwrap();
+        atomic_write(&path, b"two").unwrap();
+        assert_eq!(std::fs::read(&path).unwrap(), b"two");
+        assert!(!temp_path(&path).exists());
+    }
+}

--- a/src-tauri/reina-download/src/http.rs
+++ b/src-tauri/reina-download/src/http.rs
@@ -1,4 +1,4 @@
-//! Response validation helpers shared by the probe and the piece workers.
+//! 探测与分片请求共用的响应校验辅助。
 
 use std::time::{Duration, SystemTime};
 
@@ -7,8 +7,7 @@ use reqwest::header::{CONTENT_ENCODING, CONTENT_LENGTH, CONTENT_RANGE, HeaderMap
 
 use crate::error::DownloadError;
 
-/// Upper bound honored for `Retry-After`, so a hostile value cannot park the
-/// download for an hour.
+/// `Retry-After` 的采纳上限，防止恶意值让下载停摆过久。
 pub(crate) const MAX_RETRY_AFTER: Duration = Duration::from_secs(60);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -18,7 +17,7 @@ pub(crate) struct ContentRange {
     pub total: Option<u64>,
 }
 
-/// Parses a satisfied `Content-Range: bytes a-b/N` header. `N` may be `*`.
+/// 解析已满足的 `Content-Range: bytes a-b/N`；`N` 可为 `*`。
 pub(crate) fn parse_content_range(value: &str) -> Result<ContentRange, DownloadError> {
     let value = value.trim();
     let rest = value
@@ -59,7 +58,7 @@ pub(crate) fn parse_content_range(value: &str) -> Result<ContentRange, DownloadE
     Ok(ContentRange { start, end, total })
 }
 
-/// Parses the total from an unsatisfied `Content-Range: bytes */N` header.
+/// 从未满足的 `Content-Range: bytes */N` 中解析总长。
 pub(crate) fn parse_unsatisfied_total(value: &str) -> Result<u64, DownloadError> {
     let value = value.trim();
     let rest = value.strip_prefix("bytes ").ok_or_else(|| {
@@ -98,8 +97,7 @@ pub(crate) fn content_length(headers: &HeaderMap) -> Result<Option<u64>, Downloa
         .map_err(|error| DownloadError::Protocol(format!("invalid Content-Length: {error}")))
 }
 
-/// Rejects transfer-encoded bodies: a compressed body would make byte offsets
-/// meaningless.
+/// 拒绝带传输编码的响应体：被压缩的 body 会让字节偏移失去意义。
 pub(crate) fn ensure_identity(headers: &HeaderMap) -> Result<(), DownloadError> {
     if let Some(value) = headers.get(CONTENT_ENCODING) {
         let value = value.to_str().map_err(|error| {
@@ -125,7 +123,7 @@ pub(crate) fn header_string(
         .filter(|value| !value.is_empty())
 }
 
-/// Whether a status is worth retrying after a delay.
+/// 该状态是否值得延迟后重试。
 #[must_use]
 pub(crate) fn is_retryable_status(status: StatusCode) -> bool {
     status == StatusCode::REQUEST_TIMEOUT
@@ -141,7 +139,7 @@ pub(crate) fn status_error(status: StatusCode) -> DownloadError {
     }
 }
 
-/// Parses `Retry-After` as either delay-seconds or an HTTP date.
+/// 解析 `Retry-After`（秒数或 HTTP 日期两种形式）。
 pub(crate) fn retry_after(headers: &HeaderMap, now: SystemTime) -> Option<Duration> {
     let value = headers.get(RETRY_AFTER)?.to_str().ok()?.trim();
     let delay = if let Ok(seconds) = value.parse::<u64>() {

--- a/src-tauri/reina-download/src/http.rs
+++ b/src-tauri/reina-download/src/http.rs
@@ -1,0 +1,218 @@
+//! Response validation helpers shared by the probe and the piece workers.
+
+use std::time::{Duration, SystemTime};
+
+use reqwest::StatusCode;
+use reqwest::header::{CONTENT_ENCODING, CONTENT_LENGTH, CONTENT_RANGE, HeaderMap, RETRY_AFTER};
+
+use crate::error::DownloadError;
+
+/// Upper bound honored for `Retry-After`, so a hostile value cannot park the
+/// download for an hour.
+pub(crate) const MAX_RETRY_AFTER: Duration = Duration::from_secs(60);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ContentRange {
+    pub start: u64,
+    pub end: u64,
+    pub total: Option<u64>,
+}
+
+/// Parses a satisfied `Content-Range: bytes a-b/N` header. `N` may be `*`.
+pub(crate) fn parse_content_range(value: &str) -> Result<ContentRange, DownloadError> {
+    let value = value.trim();
+    let rest = value
+        .strip_prefix("bytes ")
+        .or_else(|| value.strip_prefix("bytes="))
+        .ok_or_else(|| {
+            DownloadError::Protocol(format!("Content-Range is not in bytes: {value}"))
+        })?;
+    let (range, total) = rest
+        .split_once('/')
+        .ok_or_else(|| DownloadError::Protocol(format!("malformed Content-Range: {value}")))?;
+    if range.trim() == "*" {
+        return Err(DownloadError::Protocol(format!(
+            "unsatisfied Content-Range where a byte range was expected: {value}"
+        )));
+    }
+    let total = match total.trim() {
+        "*" => None,
+        digits => Some(digits.parse::<u64>().map_err(|error| {
+            DownloadError::Protocol(format!("invalid Content-Range total: {error}"))
+        })?),
+    };
+    let (start, end) = range
+        .split_once('-')
+        .ok_or_else(|| DownloadError::Protocol(format!("malformed Content-Range: {value}")))?;
+    let start = start.trim().parse::<u64>().map_err(|error| {
+        DownloadError::Protocol(format!("invalid Content-Range start: {error}"))
+    })?;
+    let end = end
+        .trim()
+        .parse::<u64>()
+        .map_err(|error| DownloadError::Protocol(format!("invalid Content-Range end: {error}")))?;
+    if start > end || total.is_some_and(|total| end >= total) {
+        return Err(DownloadError::Protocol(format!(
+            "invalid Content-Range bounds: {value}"
+        )));
+    }
+    Ok(ContentRange { start, end, total })
+}
+
+/// Parses the total from an unsatisfied `Content-Range: bytes */N` header.
+pub(crate) fn parse_unsatisfied_total(value: &str) -> Result<u64, DownloadError> {
+    let value = value.trim();
+    let rest = value.strip_prefix("bytes ").ok_or_else(|| {
+        DownloadError::Protocol(format!("Content-Range is not in bytes: {value}"))
+    })?;
+    let total = rest.strip_prefix("*/").ok_or_else(|| {
+        DownloadError::Protocol(format!("expected unsatisfied Content-Range, got: {value}"))
+    })?;
+    total
+        .trim()
+        .parse::<u64>()
+        .map_err(|error| DownloadError::Protocol(format!("invalid Content-Range total: {error}")))
+}
+
+pub(crate) fn content_range(headers: &HeaderMap) -> Result<Option<ContentRange>, DownloadError> {
+    let Some(value) = headers.get(CONTENT_RANGE) else {
+        return Ok(None);
+    };
+    let value = value.to_str().map_err(|error| {
+        DownloadError::Protocol(format!("invalid Content-Range header: {error}"))
+    })?;
+    parse_content_range(value).map(Some)
+}
+
+pub(crate) fn content_length(headers: &HeaderMap) -> Result<Option<u64>, DownloadError> {
+    let Some(value) = headers.get(CONTENT_LENGTH) else {
+        return Ok(None);
+    };
+    let value = value.to_str().map_err(|error| {
+        DownloadError::Protocol(format!("invalid Content-Length header: {error}"))
+    })?;
+    value
+        .trim()
+        .parse::<u64>()
+        .map(Some)
+        .map_err(|error| DownloadError::Protocol(format!("invalid Content-Length: {error}")))
+}
+
+/// Rejects transfer-encoded bodies: a compressed body would make byte offsets
+/// meaningless.
+pub(crate) fn ensure_identity(headers: &HeaderMap) -> Result<(), DownloadError> {
+    if let Some(value) = headers.get(CONTENT_ENCODING) {
+        let value = value.to_str().map_err(|error| {
+            DownloadError::Protocol(format!("invalid Content-Encoding: {error}"))
+        })?;
+        if !value.trim().eq_ignore_ascii_case("identity") {
+            return Err(DownloadError::Protocol(format!(
+                "unexpected Content-Encoding {value}; byte ranges require identity"
+            )));
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn header_string(
+    headers: &HeaderMap,
+    name: reqwest::header::HeaderName,
+) -> Option<String> {
+    headers
+        .get(name)
+        .and_then(|value| value.to_str().ok())
+        .map(|value| value.trim().to_owned())
+        .filter(|value| !value.is_empty())
+}
+
+/// Whether a status is worth retrying after a delay.
+#[must_use]
+pub(crate) fn is_retryable_status(status: StatusCode) -> bool {
+    status == StatusCode::REQUEST_TIMEOUT
+        || status == StatusCode::TOO_EARLY
+        || status == StatusCode::TOO_MANY_REQUESTS
+        || status.is_server_error()
+}
+
+pub(crate) fn status_error(status: StatusCode) -> DownloadError {
+    DownloadError::Http {
+        status: status.as_u16(),
+        retryable: is_retryable_status(status),
+    }
+}
+
+/// Parses `Retry-After` as either delay-seconds or an HTTP date.
+pub(crate) fn retry_after(headers: &HeaderMap, now: SystemTime) -> Option<Duration> {
+    let value = headers.get(RETRY_AFTER)?.to_str().ok()?.trim();
+    let delay = if let Ok(seconds) = value.parse::<u64>() {
+        Duration::from_secs(seconds)
+    } else {
+        httpdate::parse_http_date(value)
+            .ok()?
+            .duration_since(now)
+            .unwrap_or(Duration::ZERO)
+    };
+    Some(delay.min(MAX_RETRY_AFTER))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_content_range_variants() {
+        assert_eq!(
+            parse_content_range("bytes 0-9/100").unwrap(),
+            ContentRange {
+                start: 0,
+                end: 9,
+                total: Some(100)
+            }
+        );
+        assert_eq!(
+            parse_content_range("bytes 5-5/*").unwrap(),
+            ContentRange {
+                start: 5,
+                end: 5,
+                total: None
+            }
+        );
+        assert!(parse_content_range("bytes 10-9/100").is_err());
+        assert!(parse_content_range("bytes 0-100/100").is_err());
+        assert!(parse_content_range("bytes */100").is_err());
+        assert!(parse_content_range("items 0-1/2").is_err());
+        assert_eq!(parse_unsatisfied_total("bytes */42").unwrap(), 42);
+        assert!(parse_unsatisfied_total("bytes 0-1/42").is_err());
+    }
+
+    #[test]
+    fn classifies_statuses() {
+        assert!(is_retryable_status(StatusCode::TOO_MANY_REQUESTS));
+        assert!(is_retryable_status(StatusCode::BAD_GATEWAY));
+        assert!(is_retryable_status(StatusCode::REQUEST_TIMEOUT));
+        assert!(!is_retryable_status(StatusCode::FORBIDDEN));
+        assert!(!is_retryable_status(StatusCode::NOT_FOUND));
+        assert!(!is_retryable_status(StatusCode::RANGE_NOT_SATISFIABLE));
+    }
+
+    #[test]
+    fn parses_retry_after() {
+        let mut headers = HeaderMap::new();
+        headers.insert(RETRY_AFTER, "7".parse().unwrap());
+        assert_eq!(
+            retry_after(&headers, SystemTime::now()),
+            Some(Duration::from_secs(7))
+        );
+        headers.insert(RETRY_AFTER, "100000".parse().unwrap());
+        assert_eq!(
+            retry_after(&headers, SystemTime::now()),
+            Some(MAX_RETRY_AFTER)
+        );
+        let now = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000_000);
+        let later = httpdate::fmt_http_date(now + Duration::from_secs(30));
+        headers.insert(RETRY_AFTER, later.parse().unwrap());
+        assert_eq!(retry_after(&headers, now), Some(Duration::from_secs(30)));
+        headers.insert(RETRY_AFTER, "garbage".parse().unwrap());
+        assert_eq!(retry_after(&headers, now), None);
+    }
+}

--- a/src-tauri/reina-download/src/lib.rs
+++ b/src-tauri/reina-download/src/lib.rs
@@ -1,30 +1,19 @@
-//! Segmented, resumable HTTP downloader for ReinaManager's install pipeline.
+//! ReinaManager 安装流水线使用的分段续传 HTTP 下载核心。
 //!
-//! One call to [`download`] transfers one file. Multi-task queueing, ordering,
-//! and the "how many installs at once" policy belong to the caller; a
-//! [`SharedBudget`] passed through [`DownloadOptions`] caps total connections
-//! across concurrent calls.
+//! 一次 [`download`] 调用传输一个文件；多任务排队与并发数由调用方负责，
+//! 跨任务的总连接数用 [`SharedBudget`] 约束。
 //!
-//! # Contract
+//! 约定：
+//! - 文件按固定分片（默认 4 MiB）下载，片内记录连续已写字节数，
+//!   中断只损失未落盘的页缓存；
+//! - 进度存于旁路控制文件（`target` + [`CONTROL_SUFFIX`]），fdatasync 后
+//!   原子写入，只会低估不会高估；目标文件存在且无控制文件即视为完成；
+//! - 续传身份是 `expected_size` 加 `identity` 校验和，与 URL 无关，
+//!   换签名直链可以续传；无校验和时以 ETag/Last-Modified 为准；
+//! - 取消（暂停与取消对核心等价）先落盘再返回 [`Outcome::Cancelled`]，
+//!   不算错误；服务器忽略 Range 时回退单流，中断后从头重来。
 //!
-//! - The file is split into fixed-size pieces (default 4 MiB). Progress within
-//!   each piece is tracked as a contiguous byte count, so an interruption loses
-//!   at most the unflushed page cache, not whole pieces.
-//! - State lives in a sidecar control file (`target` + [`CONTROL_SUFFIX`]),
-//!   written atomically about every 2 seconds after an `fdatasync`, and only
-//!   ever *under*-reporting what is durable. Target present with no control
-//!   file means the download is complete.
-//! - Resume identity is `expected_size` plus the caller's `identity` checksum
-//!   string. The URL is not part of the identity: a refreshed signed link
-//!   resumes where the old one stopped. Without an identity, changed
-//!   `ETag`/`Last-Modified` validators discard the partial file.
-//! - Cancellation (pause and cancel look the same here) flushes state and
-//!   returns [`Outcome::Cancelled`] quickly; it is never an error.
-//! - Servers that ignore `Range` get a single-stream fallback that restarts
-//!   from zero on interruption.
-//!
-//! The caller owns final content verification (sha256/blake3): this crate
-//! guarantees byte placement, not content.
+//! 最终内容校验（sha256/blake3）由调用方负责，核心只保证字节落位。
 
 mod control;
 mod engine;
@@ -39,6 +28,6 @@ pub use control::{CONTROL_SUFFIX, artifact_paths, control_path};
 pub use engine::download;
 pub use error::DownloadError;
 pub use progress::{Phase, Progress};
-// Re-exported so callers can drive cancellation without adding tokio-util.
+// 重新导出，调用方无需直接依赖 tokio-util。
 pub use tokio_util::sync::CancellationToken;
 pub use types::{DEFAULT_PIECE_SIZE, DownloadOptions, DownloadRequest, Outcome, SharedBudget};

--- a/src-tauri/reina-download/src/lib.rs
+++ b/src-tauri/reina-download/src/lib.rs
@@ -1,0 +1,44 @@
+//! Segmented, resumable HTTP downloader for ReinaManager's install pipeline.
+//!
+//! One call to [`download`] transfers one file. Multi-task queueing, ordering,
+//! and the "how many installs at once" policy belong to the caller; a
+//! [`SharedBudget`] passed through [`DownloadOptions`] caps total connections
+//! across concurrent calls.
+//!
+//! # Contract
+//!
+//! - The file is split into fixed-size pieces (default 4 MiB). Progress within
+//!   each piece is tracked as a contiguous byte count, so an interruption loses
+//!   at most the unflushed page cache, not whole pieces.
+//! - State lives in a sidecar control file (`target` + [`CONTROL_SUFFIX`]),
+//!   written atomically about every 2 seconds after an `fdatasync`, and only
+//!   ever *under*-reporting what is durable. Target present with no control
+//!   file means the download is complete.
+//! - Resume identity is `expected_size` plus the caller's `identity` checksum
+//!   string. The URL is not part of the identity: a refreshed signed link
+//!   resumes where the old one stopped. Without an identity, changed
+//!   `ETag`/`Last-Modified` validators discard the partial file.
+//! - Cancellation (pause and cancel look the same here) flushes state and
+//!   returns [`Outcome::Cancelled`] quickly; it is never an error.
+//! - Servers that ignore `Range` get a single-stream fallback that restarts
+//!   from zero on interruption.
+//!
+//! The caller owns final content verification (sha256/blake3): this crate
+//! guarantees byte placement, not content.
+
+mod control;
+mod engine;
+mod error;
+mod fsx;
+mod http;
+mod limiter;
+mod progress;
+mod types;
+
+pub use control::{CONTROL_SUFFIX, artifact_paths, control_path};
+pub use engine::download;
+pub use error::DownloadError;
+pub use progress::{Phase, Progress};
+// Re-exported so callers can drive cancellation without adding tokio-util.
+pub use tokio_util::sync::CancellationToken;
+pub use types::{DEFAULT_PIECE_SIZE, DownloadOptions, DownloadRequest, Outcome, SharedBudget};

--- a/src-tauri/reina-download/src/limiter.rs
+++ b/src-tauri/reina-download/src/limiter.rs
@@ -1,0 +1,225 @@
+//! Concurrency control.
+//!
+//! [`Gate`] is a resizable counting limiter used for the cross-download budget.
+//! [`Adaptive`] tracks a per-download connection target that halves on rate
+//! limiting and grows back after a run of successes.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use tokio::sync::Notify;
+use tokio_util::sync::CancellationToken;
+
+/// A resizable async counting semaphore.
+#[derive(Debug, Clone)]
+pub(crate) struct Gate {
+    inner: Arc<GateInner>,
+}
+
+#[derive(Debug)]
+struct GateInner {
+    state: Mutex<GateState>,
+    notify: Notify,
+}
+
+#[derive(Debug)]
+struct GateState {
+    max: usize,
+    in_flight: usize,
+}
+
+/// Releases one slot on drop.
+#[derive(Debug)]
+pub(crate) struct GatePermit {
+    inner: Arc<GateInner>,
+}
+
+impl Gate {
+    pub(crate) fn new(max: usize) -> Self {
+        Self {
+            inner: Arc::new(GateInner {
+                state: Mutex::new(GateState {
+                    max: max.max(1),
+                    in_flight: 0,
+                }),
+                notify: Notify::new(),
+            }),
+        }
+    }
+
+    /// Waits for a slot, or returns `None` if `cancel` fires first.
+    pub(crate) async fn acquire(&self, cancel: &CancellationToken) -> Option<GatePermit> {
+        loop {
+            let notified = {
+                let mut state = self.lock();
+                if state.in_flight < state.max {
+                    state.in_flight += 1;
+                    return Some(GatePermit {
+                        inner: Arc::clone(&self.inner),
+                    });
+                }
+                self.inner.notify.notified()
+            };
+            tokio::select! {
+                biased;
+                () = cancel.cancelled() => return None,
+                () = notified => {}
+            }
+        }
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, GateState> {
+        self.inner
+            .state
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+    }
+}
+
+impl Drop for GatePermit {
+    fn drop(&mut self) {
+        {
+            let mut state = self
+                .inner
+                .state
+                .lock()
+                .unwrap_or_else(|error| error.into_inner());
+            state.in_flight = state.in_flight.saturating_sub(1);
+        }
+        self.inner.notify.notify_one();
+    }
+}
+
+/// Per-download adaptive connection target.
+#[derive(Debug)]
+pub(crate) struct Adaptive {
+    min: usize,
+    max: usize,
+    target: AtomicUsize,
+    grow_after: u32,
+    successes: AtomicUsize,
+    timing: Mutex<Timing>,
+}
+
+#[derive(Debug)]
+struct Timing {
+    last_change: Option<Instant>,
+    not_before: Instant,
+}
+
+impl Adaptive {
+    pub(crate) fn new(min: usize, initial: usize, max: usize, grow_after: u32) -> Self {
+        Self {
+            min: min.max(1),
+            max: max.max(min.max(1)),
+            target: AtomicUsize::new(initial.clamp(min.max(1), max.max(min.max(1)))),
+            grow_after,
+            successes: AtomicUsize::new(0),
+            timing: Mutex::new(Timing {
+                last_change: None,
+                not_before: Instant::now(),
+            }),
+        }
+    }
+
+    pub(crate) fn current(&self) -> usize {
+        self.target.load(Ordering::Relaxed)
+    }
+
+    /// Delay to wait before the next request, from a `Retry-After`-driven pause.
+    pub(crate) fn remaining_pause(&self) -> Duration {
+        let timing = self.lock();
+        timing.not_before.saturating_duration_since(Instant::now())
+    }
+
+    /// Records a rate limit observed by an attempt that started at
+    /// `attempt_started`. Halves the target once per change window and extends
+    /// the shared pause by `delay`.
+    pub(crate) fn on_rate_limited(&self, attempt_started: Instant, delay: Duration) {
+        let now = Instant::now();
+        let mut timing = self.lock();
+        timing.not_before = timing.not_before.max(now + delay);
+        self.decrease(attempt_started, now, &mut timing);
+        self.successes.store(0, Ordering::Relaxed);
+    }
+
+    pub(crate) fn on_success(&self) {
+        let streak = self.successes.fetch_add(1, Ordering::Relaxed) + 1;
+        if streak >= self.grow_after as usize {
+            self.successes.store(0, Ordering::Relaxed);
+            let current = self.current();
+            if current < self.max {
+                self.target.store(current + 1, Ordering::Relaxed);
+            }
+        }
+    }
+
+    fn decrease(&self, attempt_started: Instant, now: Instant, timing: &mut Timing) {
+        // Only one reduction per window, so a burst of failures from the same
+        // batch does not collapse the target all the way to the floor.
+        if timing
+            .last_change
+            .is_some_and(|last| attempt_started <= last)
+        {
+            return;
+        }
+        let current = self.current();
+        if current <= self.min {
+            return;
+        }
+        let next = current.div_ceil(2).max(self.min);
+        self.target.store(next, Ordering::Relaxed);
+        timing.last_change = Some(now);
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, Timing> {
+        self.timing
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn gate_caps_in_flight() {
+        let gate = Gate::new(2);
+        let cancel = CancellationToken::new();
+        let a = gate.acquire(&cancel).await.unwrap();
+        let b = gate.acquire(&cancel).await.unwrap();
+        let cancel2 = cancel.clone();
+        let pending = tokio::spawn({
+            let gate = gate.clone();
+            async move { gate.acquire(&cancel2).await.is_some() }
+        });
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        assert!(!pending.is_finished());
+        drop(a);
+        assert!(pending.await.unwrap());
+        drop(b);
+    }
+
+    #[test]
+    fn adaptive_halves_then_grows() {
+        let adaptive = Adaptive::new(1, 8, 8, 2);
+        let start = Instant::now();
+        adaptive.on_rate_limited(start, Duration::from_millis(0));
+        assert_eq!(adaptive.current(), 4);
+        // Same window: a second failure from an earlier attempt does not reduce again.
+        adaptive.on_rate_limited(start, Duration::from_millis(0));
+        assert_eq!(adaptive.current(), 4);
+        adaptive.on_success();
+        adaptive.on_success();
+        assert_eq!(adaptive.current(), 5);
+    }
+
+    #[test]
+    fn adaptive_respects_floor() {
+        let adaptive = Adaptive::new(2, 2, 8, 4);
+        adaptive.on_rate_limited(Instant::now(), Duration::from_millis(0));
+        assert_eq!(adaptive.current(), 2);
+    }
+}

--- a/src-tauri/reina-download/src/limiter.rs
+++ b/src-tauri/reina-download/src/limiter.rs
@@ -1,8 +1,7 @@
-//! Concurrency control.
+//! 并发控制。
 //!
-//! [`Gate`] is a resizable counting limiter used for the cross-download budget.
-//! [`Adaptive`] tracks a per-download connection target that halves on rate
-//! limiting and grows back after a run of successes.
+//! [`Gate`] 是上限可调的计数限流器，用于跨下载连接预算；[`Adaptive`]
+//! 维护单个下载的连接目标：限流时减半，连续成功后回升。
 
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
@@ -11,7 +10,7 @@ use std::time::{Duration, Instant};
 use tokio::sync::Notify;
 use tokio_util::sync::CancellationToken;
 
-/// A resizable async counting semaphore.
+/// 上限可调的异步计数信号量。
 #[derive(Debug, Clone)]
 pub(crate) struct Gate {
     inner: Arc<GateInner>,
@@ -29,7 +28,7 @@ struct GateState {
     in_flight: usize,
 }
 
-/// Releases one slot on drop.
+/// drop 时释放一个槽位。
 #[derive(Debug)]
 pub(crate) struct GatePermit {
     inner: Arc<GateInner>,
@@ -48,7 +47,7 @@ impl Gate {
         }
     }
 
-    /// Waits for a slot, or returns `None` if `cancel` fires first.
+    /// 等待空闲槽位；`cancel` 先触发则返回 `None`。
     pub(crate) async fn acquire(&self, cancel: &CancellationToken) -> Option<GatePermit> {
         loop {
             let notified = {
@@ -91,7 +90,7 @@ impl Drop for GatePermit {
     }
 }
 
-/// Per-download adaptive connection target.
+/// 单个下载的自适应连接目标。
 #[derive(Debug)]
 pub(crate) struct Adaptive {
     min: usize,
@@ -127,15 +126,13 @@ impl Adaptive {
         self.target.load(Ordering::Relaxed)
     }
 
-    /// Delay to wait before the next request, from a `Retry-After`-driven pause.
+    /// 距下一次允许请求的等待时长（来自 Retry-After 的全局暂停）。
     pub(crate) fn remaining_pause(&self) -> Duration {
         let timing = self.lock();
         timing.not_before.saturating_duration_since(Instant::now())
     }
 
-    /// Records a rate limit observed by an attempt that started at
-    /// `attempt_started`. Halves the target once per change window and extends
-    /// the shared pause by `delay`.
+    /// 记录一次限流：目标减半（同一窗口只减一次），全局暂停延长 `delay`。
     pub(crate) fn on_rate_limited(&self, attempt_started: Instant, delay: Duration) {
         let now = Instant::now();
         let mut timing = self.lock();
@@ -156,8 +153,7 @@ impl Adaptive {
     }
 
     fn decrease(&self, attempt_started: Instant, now: Instant, timing: &mut Timing) {
-        // Only one reduction per window, so a burst of failures from the same
-        // batch does not collapse the target all the way to the floor.
+        // 同一窗口只减一次，同批连接的连锁失败不会把目标直接打到底。
         if timing
             .last_change
             .is_some_and(|last| attempt_started <= last)
@@ -208,7 +204,7 @@ mod tests {
         let start = Instant::now();
         adaptive.on_rate_limited(start, Duration::from_millis(0));
         assert_eq!(adaptive.current(), 4);
-        // Same window: a second failure from an earlier attempt does not reduce again.
+        // 同一窗口内更早发起的尝试再次失败，不重复减半。
         adaptive.on_rate_limited(start, Duration::from_millis(0));
         assert_eq!(adaptive.current(), 4);
         adaptive.on_success();

--- a/src-tauri/reina-download/src/progress.rs
+++ b/src-tauri/reina-download/src/progress.rs
@@ -1,0 +1,127 @@
+//! Progress reporting: a shared atomic snapshot and a phase enum.
+//!
+//! A dedicated emitter task samples these atomics on a fixed short interval and
+//! pushes a [`Progress`] into the caller's `watch` channel, so UI updates stay
+//! smooth regardless of how the transfer bunches up.
+
+use std::sync::atomic::{AtomicU32, AtomicU64, AtomicUsize, Ordering};
+
+/// Coarse stage of a download, surfaced to the UI.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum Phase {
+    /// Sending the initial range probe.
+    Probing = 0,
+    /// Downloading with parallel range requests.
+    Downloading = 1,
+    /// Server does not support ranges; downloading in one stream.
+    SingleStream = 2,
+    /// Flushing the last bytes and removing the control file.
+    Finalizing = 3,
+    /// Finished successfully.
+    Done = 4,
+    /// Stopped for pause or cancel.
+    Cancelled = 5,
+}
+
+impl Phase {
+    #[must_use]
+    pub(crate) fn from_u8(value: u8) -> Self {
+        match value {
+            0 => Self::Probing,
+            1 => Self::Downloading,
+            2 => Self::SingleStream,
+            3 => Self::Finalizing,
+            5 => Self::Cancelled,
+            _ => Self::Done,
+        }
+    }
+}
+
+/// A point-in-time snapshot delivered over the progress channel.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Progress {
+    pub phase: Phase,
+    /// Total size in bytes; `0` until the probe completes.
+    pub total: u64,
+    /// Bytes flushed to disk and recorded in the control file. Survives a crash.
+    pub committed: u64,
+    /// Bytes written to the page cache. Monotonic; use this for the UI bar.
+    pub written: u64,
+    /// Smoothed transfer speed in bytes per second.
+    pub speed_bps: f64,
+    /// Active connection count target.
+    pub connections: usize,
+    /// Cumulative retry count.
+    pub retries: u32,
+}
+
+impl Progress {
+    /// The value to seed the caller's `watch` channel with.
+    #[must_use]
+    pub fn initial() -> Self {
+        Self {
+            phase: Phase::Probing,
+            total: 0,
+            committed: 0,
+            written: 0,
+            speed_bps: 0.0,
+            connections: 0,
+            retries: 0,
+        }
+    }
+}
+
+/// Atomic backing store updated by the workers and committer.
+#[derive(Debug)]
+pub(crate) struct Shared {
+    phase: AtomicU8Cell,
+    total: AtomicU64,
+    pub written: AtomicU64,
+    pub committed: AtomicU64,
+    pub connections: AtomicUsize,
+    pub retries: AtomicU32,
+}
+
+impl Shared {
+    pub(crate) fn new() -> Self {
+        Self {
+            phase: AtomicU8Cell::new(Phase::Probing as u8),
+            total: AtomicU64::new(0),
+            written: AtomicU64::new(0),
+            committed: AtomicU64::new(0),
+            connections: AtomicUsize::new(0),
+            retries: AtomicU32::new(0),
+        }
+    }
+
+    pub(crate) fn set_phase(&self, phase: Phase) {
+        self.phase.0.store(phase as u8, Ordering::Relaxed);
+    }
+
+    pub(crate) fn set_total(&self, total: u64) {
+        self.total.store(total, Ordering::Relaxed);
+    }
+
+    pub(crate) fn snapshot(&self, speed_bps: f64) -> Progress {
+        Progress {
+            phase: Phase::from_u8(self.phase.0.load(Ordering::Relaxed)),
+            total: self.total.load(Ordering::Relaxed),
+            committed: self.committed.load(Ordering::Relaxed),
+            written: self.written.load(Ordering::Relaxed),
+            speed_bps,
+            connections: self.connections.load(Ordering::Relaxed),
+            retries: self.retries.load(Ordering::Relaxed),
+        }
+    }
+}
+
+// A tiny newtype so the struct field reads clearly.
+#[derive(Debug)]
+struct AtomicU8Cell(std::sync::atomic::AtomicU8);
+
+impl AtomicU8Cell {
+    fn new(value: u8) -> Self {
+        Self(std::sync::atomic::AtomicU8::new(value))
+    }
+}

--- a/src-tauri/reina-download/src/progress.rs
+++ b/src-tauri/reina-download/src/progress.rs
@@ -1,26 +1,24 @@
-//! Progress reporting: a shared atomic snapshot and a phase enum.
+//! 进度上报：共享原子快照与阶段枚举。
 //!
-//! A dedicated emitter task samples these atomics on a fixed short interval and
-//! pushes a [`Progress`] into the caller's `watch` channel, so UI updates stay
-//! smooth regardless of how the transfer bunches up.
+//! 独立任务按固定间隔采样并推送 [`Progress`]，UI 刷新与传输节奏解耦。
 
 use std::sync::atomic::{AtomicU32, AtomicU64, AtomicUsize, Ordering};
 
-/// Coarse stage of a download, surfaced to the UI.
+/// 下载所处的阶段，供 UI 展示。
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
 pub enum Phase {
-    /// Sending the initial range probe.
+    /// 正在发送初始 Range 探测。
     Probing = 0,
-    /// Downloading with parallel range requests.
+    /// 多连接分段下载中。
     Downloading = 1,
-    /// Server does not support ranges; downloading in one stream.
+    /// 服务器不支持 Range，单流下载中。
     SingleStream = 2,
-    /// Flushing the last bytes and removing the control file.
+    /// 正在落盘收尾并移除控制文件。
     Finalizing = 3,
-    /// Finished successfully.
+    /// 已成功完成。
     Done = 4,
-    /// Stopped for pause or cancel.
+    /// 因暂停或取消而停止。
     Cancelled = 5,
 }
 
@@ -38,26 +36,26 @@ impl Phase {
     }
 }
 
-/// A point-in-time snapshot delivered over the progress channel.
+/// 通过进度通道推送的时点快照。
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Progress {
     pub phase: Phase,
-    /// Total size in bytes; `0` until the probe completes.
+    /// 总大小；探测完成前为 0。
     pub total: u64,
-    /// Bytes flushed to disk and recorded in the control file. Survives a crash.
+    /// 已落盘且写入控制文件的字节数，崩溃后仍然有效。
     pub committed: u64,
-    /// Bytes written to the page cache. Monotonic; use this for the UI bar.
+    /// 已写入页缓存的字节数，单调递增，UI 进度条用它。
     pub written: u64,
-    /// Smoothed transfer speed in bytes per second.
+    /// 平滑后的速度（字节/秒）。
     pub speed_bps: f64,
-    /// Active connection count target.
+    /// 当前连接数目标。
     pub connections: usize,
-    /// Cumulative retry count.
+    /// 累计重试次数。
     pub retries: u32,
 }
 
 impl Progress {
-    /// The value to seed the caller's `watch` channel with.
+    /// 用于初始化调用方 watch 通道的初值。
     #[must_use]
     pub fn initial() -> Self {
         Self {
@@ -72,7 +70,7 @@ impl Progress {
     }
 }
 
-/// Atomic backing store updated by the workers and committer.
+/// 由 worker 与提交器更新的原子后备存储。
 #[derive(Debug)]
 pub(crate) struct Shared {
     phase: AtomicU8Cell,
@@ -116,7 +114,7 @@ impl Shared {
     }
 }
 
-// A tiny newtype so the struct field reads clearly.
+// 小包装类型，让字段读起来更清楚。
 #[derive(Debug)]
 struct AtomicU8Cell(std::sync::atomic::AtomicU8);
 

--- a/src-tauri/reina-download/src/types.rs
+++ b/src-tauri/reina-download/src/types.rs
@@ -5,59 +5,53 @@ use std::time::Duration;
 use crate::error::DownloadError;
 use crate::limiter::Gate;
 
-/// Default piece size: small enough that a pause or crash loses seconds, large
-/// enough that a multi-gigabyte file stays under a few thousand requests.
+/// 默认分片大小：足够小让中断损失以秒计，又不会让大文件产生过多请求。
 pub const DEFAULT_PIECE_SIZE: u64 = 4 * 1024 * 1024;
 
-/// What to download and where to put it.
+/// 下载请求：下什么、写到哪。
 #[derive(Debug, Clone)]
 pub struct DownloadRequest {
-    /// Source URL. May differ from the URL used on a previous attempt; resume
-    /// keys on size and identity, not URL.
+    /// 下载地址。续传身份与 URL 无关，重试时可以换新直链。
     pub url: String,
-    /// Destination path. The control file is `target` + [`crate::CONTROL_SUFFIX`].
+    /// 目标路径；控制文件为 `target` + [`crate::CONTROL_SUFFIX`]。
     pub target: PathBuf,
-    /// Size the caller expects, from the install request. The server's reported
-    /// size must match this.
+    /// 调用方期望的文件大小，服务器报告的大小必须与之一致。
     pub expected_size: u64,
-    /// Stable content identity such as `"sha256:abc…"`. When present, changed
-    /// `ETag`/`Last-Modified` do not abort a resume, because the caller verifies
-    /// the finished file anyway.
+    /// 内容标识（如 `"sha256:…"`）。提供时 ETag/Last-Modified 漂移不中断
+    /// 续传，最终哈希校验由调用方兜底。
     pub identity: Option<String>,
 }
 
-/// A shared cap on concurrent connections across several downloads, so running
-/// two installs at once cannot flood one CDN.
+/// 跨下载共享的连接总数上限，避免多任务并行时打爆同一 CDN。
 #[derive(Debug, Clone)]
 pub struct SharedBudget(pub(crate) Gate);
 
 impl SharedBudget {
-    /// Creates a budget allowing `max` concurrent connections in total.
+    /// 创建总共允许 `max` 条并发连接的预算。
     #[must_use]
     pub fn new(max: usize) -> Self {
         Self(Gate::new(max))
     }
 }
 
-/// Tunables for a single download. [`Default`] matches the values documented in
-/// the design proposal.
+/// 单个下载的可调参数；[`Default`] 即设计方案中的默认值。
 #[derive(Debug, Clone)]
 pub struct DownloadOptions {
     pub piece_size: u64,
     pub min_connections: usize,
     pub initial_connections: usize,
     pub max_connections: usize,
-    /// Disconnect and retry a piece after this long without any body bytes.
+    /// 单连接超过该时长没有收到字节即断开重试。
     pub stall_timeout: Duration,
-    /// How often durable progress is flushed to the control file.
+    /// 落盘进度写入控制文件的间隔。
     pub commit_interval: Duration,
-    /// How often a progress snapshot is pushed to the watch channel.
+    /// 进度快照推送到 watch 通道的间隔。
     pub progress_interval: Duration,
-    /// Grow the connection target after this many consecutive piece successes.
+    /// 连续成功该数量的分片后连接目标加一。
     pub grow_after_successes: u32,
-    /// Fail the whole download after this many consecutive retryable failures.
+    /// 连续可重试失败超过该数量则整体失败。
     pub max_consecutive_failures: u32,
-    /// Optional cross-download connection budget.
+    /// 可选的跨下载连接预算。
     pub budget: Option<SharedBudget>,
 }
 
@@ -109,11 +103,11 @@ impl DownloadOptions {
     }
 }
 
-/// How a download ended.
+/// 下载的结束方式。
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Outcome {
-    /// The target file is complete and the control file removed.
+    /// 目标文件完整，控制文件已移除。
     Completed,
-    /// Cancellation was observed; progress is persisted for a later resume.
+    /// 收到取消信号；进度已持久化，可稍后续传。
     Cancelled,
 }

--- a/src-tauri/reina-download/src/types.rs
+++ b/src-tauri/reina-download/src/types.rs
@@ -51,6 +51,9 @@ pub struct DownloadOptions {
     pub grow_after_successes: u32,
     /// 连续可重试失败超过该数量则整体失败。
     pub max_consecutive_failures: u32,
+    /// 单流模式下重新探测 Range 支持的间隔；CDN 冷缓存首次探测常拿到 200，
+    /// 缓存命中后即可升级为多连接分段下载。
+    pub upgrade_probe_interval: Duration,
     /// 可选的跨下载连接预算。
     pub budget: Option<SharedBudget>,
 }
@@ -67,6 +70,7 @@ impl Default for DownloadOptions {
             progress_interval: Duration::from_millis(250),
             grow_after_successes: 8,
             max_consecutive_failures: 20,
+            upgrade_probe_interval: Duration::from_secs(10),
             budget: None,
         }
     }

--- a/src-tauri/reina-download/src/types.rs
+++ b/src-tauri/reina-download/src/types.rs
@@ -1,0 +1,119 @@
+use std::ops::RangeInclusive;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use crate::error::DownloadError;
+use crate::limiter::Gate;
+
+/// Default piece size: small enough that a pause or crash loses seconds, large
+/// enough that a multi-gigabyte file stays under a few thousand requests.
+pub const DEFAULT_PIECE_SIZE: u64 = 4 * 1024 * 1024;
+
+/// What to download and where to put it.
+#[derive(Debug, Clone)]
+pub struct DownloadRequest {
+    /// Source URL. May differ from the URL used on a previous attempt; resume
+    /// keys on size and identity, not URL.
+    pub url: String,
+    /// Destination path. The control file is `target` + [`crate::CONTROL_SUFFIX`].
+    pub target: PathBuf,
+    /// Size the caller expects, from the install request. The server's reported
+    /// size must match this.
+    pub expected_size: u64,
+    /// Stable content identity such as `"sha256:abc…"`. When present, changed
+    /// `ETag`/`Last-Modified` do not abort a resume, because the caller verifies
+    /// the finished file anyway.
+    pub identity: Option<String>,
+}
+
+/// A shared cap on concurrent connections across several downloads, so running
+/// two installs at once cannot flood one CDN.
+#[derive(Debug, Clone)]
+pub struct SharedBudget(pub(crate) Gate);
+
+impl SharedBudget {
+    /// Creates a budget allowing `max` concurrent connections in total.
+    #[must_use]
+    pub fn new(max: usize) -> Self {
+        Self(Gate::new(max))
+    }
+}
+
+/// Tunables for a single download. [`Default`] matches the values documented in
+/// the design proposal.
+#[derive(Debug, Clone)]
+pub struct DownloadOptions {
+    pub piece_size: u64,
+    pub min_connections: usize,
+    pub initial_connections: usize,
+    pub max_connections: usize,
+    /// Disconnect and retry a piece after this long without any body bytes.
+    pub stall_timeout: Duration,
+    /// How often durable progress is flushed to the control file.
+    pub commit_interval: Duration,
+    /// How often a progress snapshot is pushed to the watch channel.
+    pub progress_interval: Duration,
+    /// Grow the connection target after this many consecutive piece successes.
+    pub grow_after_successes: u32,
+    /// Fail the whole download after this many consecutive retryable failures.
+    pub max_consecutive_failures: u32,
+    /// Optional cross-download connection budget.
+    pub budget: Option<SharedBudget>,
+}
+
+impl Default for DownloadOptions {
+    fn default() -> Self {
+        Self {
+            piece_size: DEFAULT_PIECE_SIZE,
+            min_connections: 1,
+            initial_connections: 4,
+            max_connections: 8,
+            stall_timeout: Duration::from_secs(20),
+            commit_interval: Duration::from_secs(2),
+            progress_interval: Duration::from_millis(250),
+            grow_after_successes: 8,
+            max_consecutive_failures: 20,
+            budget: None,
+        }
+    }
+}
+
+impl DownloadOptions {
+    #[must_use]
+    pub fn connections(&self) -> RangeInclusive<usize> {
+        self.min_connections..=self.max_connections
+    }
+
+    pub(crate) fn validate(&self) -> Result<(), DownloadError> {
+        if self.piece_size == 0 {
+            return Err(DownloadError::InvalidConfig(
+                "piece_size must be positive".into(),
+            ));
+        }
+        if self.min_connections == 0 {
+            return Err(DownloadError::InvalidConfig(
+                "min_connections must be >= 1".into(),
+            ));
+        }
+        if self.max_connections < self.min_connections {
+            return Err(DownloadError::InvalidConfig(
+                "max_connections must be >= min_connections".into(),
+            ));
+        }
+        Ok(())
+    }
+
+    pub(crate) fn clamped_initial(&self) -> usize {
+        self.initial_connections
+            .clamp(self.min_connections, self.max_connections)
+    }
+}
+
+/// How a download ended.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Outcome {
+    /// The target file is complete and the control file removed.
+    Completed,
+    /// Cancellation was observed; progress is persisted for a later resume.
+    Cancelled,
+}

--- a/src-tauri/reina-download/src/types.rs
+++ b/src-tauri/reina-download/src/types.rs
@@ -51,8 +51,10 @@ pub struct DownloadOptions {
     pub grow_after_successes: u32,
     /// 连续可重试失败超过该数量则整体失败。
     pub max_consecutive_failures: u32,
-    /// 单流模式下重新探测 Range 支持的间隔；CDN 冷缓存首次探测常拿到 200，
-    /// 缓存命中后即可升级为多连接分段下载。
+    /// 探测拿到 200 后进入单流前的复测等待；部分源站只在首个请求上
+    /// 忽略 Range，稍等复测即可直接走分段模式。
+    pub range_confirm_delay: Duration,
+    /// 单流模式下重新探测 Range 支持的间隔，一旦拿到 206 即升级为分段下载。
     pub upgrade_probe_interval: Duration,
     /// 可选的跨下载连接预算。
     pub budget: Option<SharedBudget>,
@@ -70,6 +72,7 @@ impl Default for DownloadOptions {
             progress_interval: Duration::from_millis(250),
             grow_after_successes: 8,
             max_consecutive_failures: 20,
+            range_confirm_delay: Duration::from_millis(1500),
             upgrade_probe_interval: Duration::from_secs(10),
             budget: None,
         }

--- a/src-tauri/reina-download/tests/download.rs
+++ b/src-tauri/reina-download/tests/download.rs
@@ -1,7 +1,6 @@
-//! Integration tests against an in-process fault-injection HTTP server.
+//! 基于进程内故障注入 HTTP 服务器的集成测试。
 //!
-//! Every scenario asserts the final file matches the source bytes exactly, so
-//! a scheduling or offset bug cannot pass silently.
+//! 每个场景都断言最终文件与源数据逐字节一致，调度或偏移错误无法蒙混过关。
 
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -18,24 +17,23 @@ use tokio::sync::watch;
 use tokio_util::sync::CancellationToken;
 
 // ---------------------------------------------------------------------------
-// Fault-injection server
+// 故障注入服务器
 
 #[derive(Debug, Clone)]
 enum Mode {
-    /// Honor ranges with 206; plain GET gets 200.
+    /// 正常响应 Range（206）；无 Range 的 GET 返回 200。
     Normal,
-    /// Always answer 200 with the full body, ignoring Range.
+    /// 无视 Range，始终 200 返回完整内容。
     IgnoreRange,
-    /// Always answer 403.
+    /// 始终 403。
     Forbidden,
-    /// 429 with `Retry-After: 0` for the first N requests, then Normal.
+    /// 前 N 个请求返回 429 加 `Retry-After: 0`，之后正常。
     RateLimitFirst(usize),
-    /// For the first N range requests, send headers then only `bytes` of body
-    /// and drop the connection.
+    /// 前 N 个 Range 请求发出头部后只发 `bytes` 字节即断开。
     DropAfter { bytes: usize, times: usize },
-    /// Report a wrong total length in Content-Range.
+    /// Content-Range 报告错误的总长。
     WrongTotal(u64),
-    /// Send response headers, then nothing, for the first N requests.
+    /// 前 N 个请求只发响应头，不发数据。
     StallFirst(usize),
 }
 
@@ -44,8 +42,7 @@ struct ServerState {
     mode: std::sync::Mutex<Mode>,
     requests: AtomicUsize,
     body_bytes_served: AtomicU64,
-    /// Delay inserted between 8 KiB body writes, to slow tests that need to
-    /// observe a download mid-flight.
+    /// 每写 8 KiB 插入的延迟，让测试能观察到下载中途的状态。
     chunk_delay: Duration,
 }
 
@@ -94,7 +91,7 @@ impl Server {
 }
 
 async fn handle(mut stream: TcpStream, state: Arc<ServerState>) -> std::io::Result<()> {
-    // Read one request's headers.
+    // 读完一个请求的头部。
     let mut buf = Vec::new();
     let mut byte = [0u8; 1];
     while !buf.ends_with(b"\r\n\r\n") {
@@ -121,8 +118,8 @@ async fn handle(mut stream: TcpStream, state: Arc<ServerState>) -> std::io::Resu
     let mode = state.mode.lock().unwrap().clone();
     match mode {
         Mode::Forbidden => return respond_status(&mut stream, "403 Forbidden").await,
-        // Let the probe (bytes=0-0) through so the rate limit lands on piece
-        // requests, exercising the adaptive-concurrency path.
+        // 放行探测请求（bytes=0-0），让 429 落在分片请求上，
+        // 以覆盖自适应并发路径。
         Mode::RateLimitFirst(remaining)
             if remaining > 0 && range.as_deref() != Some("bytes=0-0") =>
         {
@@ -139,8 +136,7 @@ async fn handle(mut stream: TcpStream, state: Arc<ServerState>) -> std::io::Resu
                 end - start + 1
             );
             stream.write_all(head.as_bytes()).await?;
-            // Send nothing further; hold the socket open until the client
-            // gives up, so the stall detector has to fire.
+            // 之后什么都不发，保持连接直到客户端放弃，逼停滞检测生效。
             tokio::time::sleep(Duration::from_secs(120)).await;
             return Ok(());
         }
@@ -201,7 +197,7 @@ async fn write_body(
         }
     }
     if cap.is_some() {
-        // Simulate an abrupt disconnect mid-body.
+        // 模拟传输中途突然断开。
         let _ = stream.shutdown().await;
     }
     Ok(())
@@ -228,10 +224,10 @@ async fn respond_status(stream: &mut TcpStream, status: &str) -> std::io::Result
 }
 
 // ---------------------------------------------------------------------------
-// Helpers
+// 辅助
 
 fn test_data(len: usize) -> Vec<u8> {
-    // Position-dependent bytes: any misplaced write changes the comparison.
+    // 字节值与位置相关，任何写错位置都会改变比较结果。
     (0..len).map(|i| ((i * 31 + i / 251) % 251) as u8).collect()
 }
 
@@ -288,7 +284,7 @@ async fn run_download(
 }
 
 // ---------------------------------------------------------------------------
-// Scenarios
+// 场景
 
 #[tokio::test]
 async fn downloads_with_multiple_connections() {
@@ -327,7 +323,7 @@ async fn resumes_after_cancel_and_url_change() {
         sender,
         cancel.clone(),
     ));
-    // Cancel once a meaningful amount has been written.
+    // 等到写入量有意义后再取消。
     loop {
         receiver.changed().await.unwrap();
         if receiver.borrow().written > 512 * 1024 {
@@ -342,7 +338,7 @@ async fn resumes_after_cancel_and_url_change() {
         "control must persist after cancel"
     );
 
-    // The control file must never claim bytes that are not really in the file.
+    // 控制文件绝不能声称文件里没有的字节。
     let control: serde_json::Value =
         serde_json::from_slice(&std::fs::read(control_path(&paths.target)).unwrap()).unwrap();
     let piece_size = control["piece_size"].as_u64().unwrap();
@@ -361,7 +357,7 @@ async fn resumes_after_cancel_and_url_change() {
         "cancel happened after progress; control should show it"
     );
 
-    // Resume with a *different* URL, as after a signed-link refresh.
+    // 换一个 URL 续传，模拟签名直链刷新。
     let served_before_resume = server.body_bytes_served();
     let (result, progress) = run_download(
         request(

--- a/src-tauri/reina-download/tests/download.rs
+++ b/src-tauri/reina-download/tests/download.rs
@@ -259,6 +259,7 @@ fn fast_options() -> DownloadOptions {
         progress_interval: Duration::from_millis(50),
         grow_after_successes: 4,
         max_consecutive_failures: 20,
+        range_confirm_delay: Duration::from_millis(100),
         upgrade_probe_interval: Duration::from_millis(150),
         budget: None,
     }
@@ -415,9 +416,31 @@ async fn falls_back_to_single_stream_when_ranges_ignored() {
 }
 
 #[tokio::test]
+async fn confirm_probe_avoids_single_stream_when_first_request_ignores_range() {
+    let data = test_data(600_000);
+    // 只有第一个请求无视 Range：复测探测应直接进入分段模式。
+    let server = Server::start(data.clone(), Mode::IgnoreRangeFirst(1), Duration::ZERO).await;
+    let paths = run_paths();
+
+    let (result, _) = run_download(
+        request(server.url("/first-only"), &paths.target, data.len() as u64),
+        fast_options(),
+    )
+    .await;
+
+    assert!(matches!(result, Ok(Outcome::Completed)), "{result:?}");
+    assert_eq!(std::fs::read(&paths.target).unwrap(), data);
+    assert!(
+        server.ranged_responses() >= 2,
+        "复测后应直接分段下载，实际 206 响应数: {}",
+        server.ranged_responses()
+    );
+}
+
+#[tokio::test]
 async fn upgrades_to_segmented_when_ranges_become_available() {
     let data = test_data(2 * 1024 * 1024);
-    // 前两个请求（探测 + 单流 GET）无视 Range，之后正常——模拟 CDN 冷缓存。
+    // 首测与复测都拿到 200，逼下载进入单流，再由后台探测触发升级。
     let server = Server::start(
         data.clone(),
         Mode::IgnoreRangeFirst(2),

--- a/src-tauri/reina-download/tests/download.rs
+++ b/src-tauri/reina-download/tests/download.rs
@@ -1,0 +1,586 @@
+//! Integration tests against an in-process fault-injection HTTP server.
+//!
+//! Every scenario asserts the final file matches the source bytes exactly, so
+//! a scheduling or offset bug cannot pass silently.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::time::Duration;
+
+use reina_download::{
+    DownloadError, DownloadOptions, DownloadRequest, Outcome, Phase, Progress, SharedBudget,
+    control_path, download,
+};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::watch;
+use tokio_util::sync::CancellationToken;
+
+// ---------------------------------------------------------------------------
+// Fault-injection server
+
+#[derive(Debug, Clone)]
+enum Mode {
+    /// Honor ranges with 206; plain GET gets 200.
+    Normal,
+    /// Always answer 200 with the full body, ignoring Range.
+    IgnoreRange,
+    /// Always answer 403.
+    Forbidden,
+    /// 429 with `Retry-After: 0` for the first N requests, then Normal.
+    RateLimitFirst(usize),
+    /// For the first N range requests, send headers then only `bytes` of body
+    /// and drop the connection.
+    DropAfter { bytes: usize, times: usize },
+    /// Report a wrong total length in Content-Range.
+    WrongTotal(u64),
+    /// Send response headers, then nothing, for the first N requests.
+    StallFirst(usize),
+}
+
+struct ServerState {
+    data: Vec<u8>,
+    mode: std::sync::Mutex<Mode>,
+    requests: AtomicUsize,
+    body_bytes_served: AtomicU64,
+    /// Delay inserted between 8 KiB body writes, to slow tests that need to
+    /// observe a download mid-flight.
+    chunk_delay: Duration,
+}
+
+struct Server {
+    state: Arc<ServerState>,
+    addr: std::net::SocketAddr,
+}
+
+impl Server {
+    async fn start(data: Vec<u8>, mode: Mode, chunk_delay: Duration) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let state = Arc::new(ServerState {
+            data,
+            mode: std::sync::Mutex::new(mode),
+            requests: AtomicUsize::new(0),
+            body_bytes_served: AtomicU64::new(0),
+            chunk_delay,
+        });
+        let accept_state = Arc::clone(&state);
+        tokio::spawn(async move {
+            loop {
+                let Ok((stream, _)) = listener.accept().await else {
+                    break;
+                };
+                let state = Arc::clone(&accept_state);
+                tokio::spawn(async move {
+                    let _ = handle(stream, state).await;
+                });
+            }
+        });
+        Self { state, addr }
+    }
+
+    fn url(&self, path: &str) -> String {
+        format!("http://{}{}", self.addr, path)
+    }
+
+    fn requests(&self) -> usize {
+        self.state.requests.load(Ordering::Relaxed)
+    }
+
+    fn body_bytes_served(&self) -> u64 {
+        self.state.body_bytes_served.load(Ordering::Relaxed)
+    }
+}
+
+async fn handle(mut stream: TcpStream, state: Arc<ServerState>) -> std::io::Result<()> {
+    // Read one request's headers.
+    let mut buf = Vec::new();
+    let mut byte = [0u8; 1];
+    while !buf.ends_with(b"\r\n\r\n") {
+        if stream.read(&mut byte).await? == 0 {
+            return Ok(());
+        }
+        buf.push(byte[0]);
+        if buf.len() > 16 * 1024 {
+            return Ok(());
+        }
+    }
+    let text = String::from_utf8_lossy(&buf);
+    let range = text
+        .lines()
+        .find_map(|line| {
+            line.to_ascii_lowercase()
+                .strip_prefix("range:")
+                .map(str::to_owned)
+        })
+        .map(|value| value.trim().to_owned());
+    state.requests.fetch_add(1, Ordering::Relaxed);
+
+    let total = state.data.len() as u64;
+    let mode = state.mode.lock().unwrap().clone();
+    match mode {
+        Mode::Forbidden => return respond_status(&mut stream, "403 Forbidden").await,
+        // Let the probe (bytes=0-0) through so the rate limit lands on piece
+        // requests, exercising the adaptive-concurrency path.
+        Mode::RateLimitFirst(remaining)
+            if remaining > 0 && range.as_deref() != Some("bytes=0-0") =>
+        {
+            *state.mode.lock().unwrap() = Mode::RateLimitFirst(remaining - 1);
+            let head = "HTTP/1.1 429 Too Many Requests\r\nRetry-After: 0\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
+            stream.write_all(head.as_bytes()).await?;
+            return Ok(());
+        }
+        Mode::StallFirst(remaining) if remaining > 0 => {
+            *state.mode.lock().unwrap() = Mode::StallFirst(remaining - 1);
+            let (start, end) = parse_range(range.as_deref(), total);
+            let head = format!(
+                "HTTP/1.1 206 Partial Content\r\nContent-Range: bytes {start}-{end}/{total}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                end - start + 1
+            );
+            stream.write_all(head.as_bytes()).await?;
+            // Send nothing further; hold the socket open until the client
+            // gives up, so the stall detector has to fire.
+            tokio::time::sleep(Duration::from_secs(120)).await;
+            return Ok(());
+        }
+        _ => {}
+    }
+
+    let ignore_range = matches!(mode, Mode::IgnoreRange);
+    match (range, ignore_range) {
+        (Some(range), false) => {
+            let (start, end) = parse_range(Some(&range), total);
+            let reported_total = match mode {
+                Mode::WrongTotal(wrong) => wrong,
+                _ => total,
+            };
+            let body = &state.data[start as usize..=end as usize];
+            let head = format!(
+                "HTTP/1.1 206 Partial Content\r\nContent-Range: bytes {start}-{end}/{reported_total}\r\nContent-Length: {}\r\nETag: \"fixed-etag\"\r\nConnection: close\r\n\r\n",
+                body.len()
+            );
+            stream.write_all(head.as_bytes()).await?;
+            let cap = match mode {
+                Mode::DropAfter { bytes, times } if times > 0 => {
+                    *state.mode.lock().unwrap() = Mode::DropAfter {
+                        bytes,
+                        times: times - 1,
+                    };
+                    Some(bytes)
+                }
+                _ => None,
+            };
+            write_body(&mut stream, body, cap, &state).await?;
+        }
+        _ => {
+            let head = format!(
+                "HTTP/1.1 200 OK\r\nContent-Length: {total}\r\nETag: \"fixed-etag\"\r\nConnection: close\r\n\r\n"
+            );
+            stream.write_all(head.as_bytes()).await?;
+            write_body(&mut stream, &state.data, None, &state).await?;
+        }
+    }
+    Ok(())
+}
+
+async fn write_body(
+    stream: &mut TcpStream,
+    body: &[u8],
+    cap: Option<usize>,
+    state: &ServerState,
+) -> std::io::Result<()> {
+    let limit = cap.unwrap_or(body.len()).min(body.len());
+    for chunk in body[..limit].chunks(8 * 1024) {
+        stream.write_all(chunk).await?;
+        state
+            .body_bytes_served
+            .fetch_add(chunk.len() as u64, Ordering::Relaxed);
+        if !state.chunk_delay.is_zero() {
+            tokio::time::sleep(state.chunk_delay).await;
+        }
+    }
+    if cap.is_some() {
+        // Simulate an abrupt disconnect mid-body.
+        let _ = stream.shutdown().await;
+    }
+    Ok(())
+}
+
+fn parse_range(range: Option<&str>, total: u64) -> (u64, u64) {
+    let Some(range) = range else {
+        return (0, total - 1);
+    };
+    let spec = range.trim().strip_prefix("bytes=").unwrap();
+    let (start, end) = spec.split_once('-').unwrap();
+    let start: u64 = start.parse().unwrap();
+    let end: u64 = if end.is_empty() {
+        total - 1
+    } else {
+        end.parse().unwrap()
+    };
+    (start, end.min(total - 1))
+}
+
+async fn respond_status(stream: &mut TcpStream, status: &str) -> std::io::Result<()> {
+    let head = format!("HTTP/1.1 {status}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n");
+    stream.write_all(head.as_bytes()).await
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+
+fn test_data(len: usize) -> Vec<u8> {
+    // Position-dependent bytes: any misplaced write changes the comparison.
+    (0..len).map(|i| ((i * 31 + i / 251) % 251) as u8).collect()
+}
+
+fn fast_options() -> DownloadOptions {
+    DownloadOptions {
+        piece_size: 64 * 1024,
+        min_connections: 1,
+        initial_connections: 4,
+        max_connections: 8,
+        stall_timeout: Duration::from_millis(600),
+        commit_interval: Duration::from_millis(150),
+        progress_interval: Duration::from_millis(50),
+        grow_after_successes: 4,
+        max_consecutive_failures: 20,
+        budget: None,
+    }
+}
+
+struct Run {
+    target: PathBuf,
+    _dir: tempfile::TempDir,
+}
+
+fn run_paths() -> Run {
+    let dir = tempfile::tempdir().unwrap();
+    let target = dir.path().join("game.7z");
+    Run { target, _dir: dir }
+}
+
+fn request(url: String, target: &std::path::Path, size: u64) -> DownloadRequest {
+    DownloadRequest {
+        url,
+        target: target.to_path_buf(),
+        expected_size: size,
+        identity: Some("sha256:test-identity".to_owned()),
+    }
+}
+
+async fn run_download(
+    request_value: DownloadRequest,
+    options: DownloadOptions,
+) -> (Result<Outcome, DownloadError>, Progress) {
+    let (sender, receiver) = watch::channel(Progress::initial());
+    let result = download(
+        request_value,
+        options,
+        reqwest::Client::new(),
+        sender,
+        CancellationToken::new(),
+    )
+    .await;
+    let progress = *receiver.borrow();
+    (result, progress)
+}
+
+// ---------------------------------------------------------------------------
+// Scenarios
+
+#[tokio::test]
+async fn downloads_with_multiple_connections() {
+    let data = test_data(1_000_003); // deliberately not piece-aligned
+    let server = Server::start(data.clone(), Mode::Normal, Duration::ZERO).await;
+    let paths = run_paths();
+
+    let (result, progress) = run_download(
+        request(server.url("/game.7z"), &paths.target, data.len() as u64),
+        fast_options(),
+    )
+    .await;
+
+    assert!(matches!(result, Ok(Outcome::Completed)), "{result:?}");
+    assert_eq!(std::fs::read(&paths.target).unwrap(), data);
+    assert!(
+        !control_path(&paths.target).exists(),
+        "control file must be removed"
+    );
+    assert_eq!(progress.phase, Phase::Done);
+    assert_eq!(progress.written, data.len() as u64);
+}
+
+#[tokio::test]
+async fn resumes_after_cancel_and_url_change() {
+    let data = test_data(2 * 1024 * 1024);
+    let server = Server::start(data.clone(), Mode::Normal, Duration::from_millis(2)).await;
+    let paths = run_paths();
+
+    let (sender, mut receiver) = watch::channel(Progress::initial());
+    let cancel = CancellationToken::new();
+    let handle = tokio::spawn(download(
+        request(server.url("/signed-v1"), &paths.target, data.len() as u64),
+        fast_options(),
+        reqwest::Client::new(),
+        sender,
+        cancel.clone(),
+    ));
+    // Cancel once a meaningful amount has been written.
+    loop {
+        receiver.changed().await.unwrap();
+        if receiver.borrow().written > 512 * 1024 {
+            break;
+        }
+    }
+    cancel.cancel();
+    let first = handle.await.unwrap();
+    assert!(matches!(first, Ok(Outcome::Cancelled)), "{first:?}");
+    assert!(
+        control_path(&paths.target).exists(),
+        "control must persist after cancel"
+    );
+
+    // The control file must never claim bytes that are not really in the file.
+    let control: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(control_path(&paths.target)).unwrap()).unwrap();
+    let piece_size = control["piece_size"].as_u64().unwrap();
+    let file_now = std::fs::read(&paths.target).unwrap();
+    let mut claimed_total = 0u64;
+    for (index, claimed) in control["pieces"].as_array().unwrap().iter().enumerate() {
+        let claimed = claimed.as_u64().unwrap();
+        claimed_total += claimed;
+        let start = index as u64 * piece_size;
+        let have = &file_now[start as usize..(start + claimed) as usize];
+        let want = &data[start as usize..(start + claimed) as usize];
+        assert_eq!(have, want, "piece {index} claims unwritten bytes");
+    }
+    assert!(
+        claimed_total > 0,
+        "cancel happened after progress; control should show it"
+    );
+
+    // Resume with a *different* URL, as after a signed-link refresh.
+    let served_before_resume = server.body_bytes_served();
+    let (result, progress) = run_download(
+        request(
+            server.url("/signed-v2-refreshed"),
+            &paths.target,
+            data.len() as u64,
+        ),
+        fast_options(),
+    )
+    .await;
+    assert!(matches!(result, Ok(Outcome::Completed)), "{result:?}");
+    assert_eq!(std::fs::read(&paths.target).unwrap(), data);
+    assert!(!control_path(&paths.target).exists());
+    assert_eq!(progress.total, data.len() as u64);
+    let served_during_resume = server.body_bytes_served() - served_before_resume;
+    assert!(
+        served_during_resume < data.len() as u64,
+        "resume re-downloaded everything: {served_during_resume} of {}",
+        data.len()
+    );
+}
+
+#[tokio::test]
+async fn falls_back_to_single_stream_when_ranges_ignored() {
+    let data = test_data(300_000);
+    let server = Server::start(data.clone(), Mode::IgnoreRange, Duration::ZERO).await;
+    let paths = run_paths();
+
+    let (result, _) = run_download(
+        request(server.url("/no-ranges"), &paths.target, data.len() as u64),
+        fast_options(),
+    )
+    .await;
+
+    assert!(matches!(result, Ok(Outcome::Completed)), "{result:?}");
+    assert_eq!(std::fs::read(&paths.target).unwrap(), data);
+}
+
+#[tokio::test]
+async fn recovers_from_rate_limiting() {
+    let data = test_data(600_000);
+    let server = Server::start(data.clone(), Mode::RateLimitFirst(3), Duration::ZERO).await;
+    let paths = run_paths();
+
+    let (result, progress) = run_download(
+        request(server.url("/limited"), &paths.target, data.len() as u64),
+        fast_options(),
+    )
+    .await;
+
+    assert!(matches!(result, Ok(Outcome::Completed)), "{result:?}");
+    assert_eq!(std::fs::read(&paths.target).unwrap(), data);
+    assert!(
+        progress.retries >= 1,
+        "rate-limited attempts must count as retries"
+    );
+}
+
+#[tokio::test]
+async fn forbidden_fails_without_retry_storm() {
+    let data = test_data(100_000);
+    let server = Server::start(data, Mode::Forbidden, Duration::ZERO).await;
+    let paths = run_paths();
+
+    let (result, _) = run_download(
+        request(server.url("/forbidden"), &paths.target, 100_000),
+        fast_options(),
+    )
+    .await;
+
+    match result {
+        Err(error) => {
+            assert_eq!(error.http_status(), Some(403), "{error:?}");
+            assert!(!error.is_retryable());
+        }
+        other => panic!("expected 403 failure, got {other:?}"),
+    }
+    assert!(
+        server.requests() <= 2,
+        "403 must not be retried; saw {}",
+        server.requests()
+    );
+}
+
+#[tokio::test]
+async fn retries_pieces_after_mid_stream_disconnects() {
+    let data = test_data(500_000);
+    let server = Server::start(
+        data.clone(),
+        Mode::DropAfter {
+            bytes: 10_000,
+            times: 6,
+        },
+        Duration::ZERO,
+    )
+    .await;
+    let paths = run_paths();
+
+    let (result, progress) = run_download(
+        request(server.url("/flaky"), &paths.target, data.len() as u64),
+        fast_options(),
+    )
+    .await;
+
+    assert!(matches!(result, Ok(Outcome::Completed)), "{result:?}");
+    assert_eq!(std::fs::read(&paths.target).unwrap(), data);
+    assert!(progress.retries >= 1);
+}
+
+#[tokio::test]
+async fn stall_detection_recovers_dead_connections() {
+    let data = test_data(400_000);
+    let server = Server::start(data.clone(), Mode::StallFirst(2), Duration::ZERO).await;
+    let paths = run_paths();
+
+    let started = std::time::Instant::now();
+    let (result, _) = run_download(
+        request(server.url("/stalls"), &paths.target, data.len() as u64),
+        fast_options(),
+    )
+    .await;
+
+    assert!(matches!(result, Ok(Outcome::Completed)), "{result:?}");
+    assert_eq!(std::fs::read(&paths.target).unwrap(), data);
+    assert!(
+        started.elapsed() < Duration::from_secs(30),
+        "stall recovery took {:?}",
+        started.elapsed()
+    );
+}
+
+#[tokio::test]
+async fn rejects_wrong_reported_size() {
+    let data = test_data(100_000);
+    let server = Server::start(data, Mode::WrongTotal(999), Duration::ZERO).await;
+    let paths = run_paths();
+
+    let (result, _) = run_download(
+        request(server.url("/wrong-size"), &paths.target, 100_000),
+        fast_options(),
+    )
+    .await;
+
+    assert!(
+        matches!(result, Err(DownloadError::SizeMismatch { .. })),
+        "{result:?}"
+    );
+}
+
+#[tokio::test]
+async fn short_circuits_when_target_already_complete() {
+    let data = test_data(50_000);
+    let server = Server::start(data.clone(), Mode::Normal, Duration::ZERO).await;
+    let paths = run_paths();
+    std::fs::write(&paths.target, &data).unwrap();
+
+    let (result, _) = run_download(
+        request(server.url("/done"), &paths.target, data.len() as u64),
+        fast_options(),
+    )
+    .await;
+
+    assert!(matches!(result, Ok(Outcome::Completed)), "{result:?}");
+    assert_eq!(
+        server.requests(),
+        0,
+        "a finished download must not touch the network"
+    );
+}
+
+#[tokio::test]
+async fn refuses_foreign_file_at_target_path() {
+    let server = Server::start(test_data(50_000), Mode::Normal, Duration::ZERO).await;
+    let paths = run_paths();
+    std::fs::write(&paths.target, b"something else entirely").unwrap();
+
+    let (result, _) = run_download(
+        request(server.url("/conflict"), &paths.target, 50_000),
+        fast_options(),
+    )
+    .await;
+
+    assert!(
+        matches!(result, Err(DownloadError::TargetConflict(_))),
+        "{result:?}"
+    );
+}
+
+#[tokio::test]
+async fn shared_budget_caps_total_connections() {
+    let data = test_data(800_000);
+    let server = Server::start(data.clone(), Mode::Normal, Duration::from_millis(1)).await;
+    let paths_a = run_paths();
+    let paths_b = run_paths();
+    let budget = SharedBudget::new(2);
+    let mut options = fast_options();
+    options.budget = Some(budget);
+
+    let (sender_a, _keep_a) = watch::channel(Progress::initial());
+    let (sender_b, _keep_b) = watch::channel(Progress::initial());
+    let (first, second) = tokio::join!(
+        download(
+            request(server.url("/a"), &paths_a.target, data.len() as u64),
+            options.clone(),
+            reqwest::Client::new(),
+            sender_a,
+            CancellationToken::new(),
+        ),
+        download(
+            request(server.url("/b"), &paths_b.target, data.len() as u64),
+            options,
+            reqwest::Client::new(),
+            sender_b,
+            CancellationToken::new(),
+        ),
+    );
+
+    assert!(matches!(first, Ok(Outcome::Completed)), "{first:?}");
+    assert!(matches!(second, Ok(Outcome::Completed)), "{second:?}");
+    assert_eq!(std::fs::read(&paths_a.target).unwrap(), data);
+    assert_eq!(std::fs::read(&paths_b.target).unwrap(), data);
+}

--- a/src-tauri/reina-download/tests/download.rs
+++ b/src-tauri/reina-download/tests/download.rs
@@ -25,6 +25,8 @@ enum Mode {
     Normal,
     /// 无视 Range，始终 200 返回完整内容。
     IgnoreRange,
+    /// 前 N 个请求无视 Range，之后正常响应 206——模拟 CDN 冷缓存。
+    IgnoreRangeFirst(usize),
     /// 始终 403。
     Forbidden,
     /// 前 N 个请求返回 429 加 `Retry-After: 0`，之后正常。
@@ -42,6 +44,8 @@ struct ServerState {
     mode: std::sync::Mutex<Mode>,
     requests: AtomicUsize,
     body_bytes_served: AtomicU64,
+    /// 已服务的 206 分段响应数。
+    ranged_responses: AtomicUsize,
     /// 每写 8 KiB 插入的延迟，让测试能观察到下载中途的状态。
     chunk_delay: Duration,
 }
@@ -60,6 +64,7 @@ impl Server {
             mode: std::sync::Mutex::new(mode),
             requests: AtomicUsize::new(0),
             body_bytes_served: AtomicU64::new(0),
+            ranged_responses: AtomicUsize::new(0),
             chunk_delay,
         });
         let accept_state = Arc::clone(&state);
@@ -83,6 +88,10 @@ impl Server {
 
     fn requests(&self) -> usize {
         self.state.requests.load(Ordering::Relaxed)
+    }
+
+    fn ranged_responses(&self) -> usize {
+        self.state.ranged_responses.load(Ordering::Relaxed)
     }
 
     fn body_bytes_served(&self) -> u64 {
@@ -143,7 +152,14 @@ async fn handle(mut stream: TcpStream, state: Arc<ServerState>) -> std::io::Resu
         _ => {}
     }
 
-    let ignore_range = matches!(mode, Mode::IgnoreRange);
+    let ignore_range = match mode {
+        Mode::IgnoreRange => true,
+        Mode::IgnoreRangeFirst(remaining) if remaining > 0 => {
+            *state.mode.lock().unwrap() = Mode::IgnoreRangeFirst(remaining - 1);
+            true
+        }
+        _ => false,
+    };
     match (range, ignore_range) {
         (Some(range), false) => {
             let (start, end) = parse_range(Some(&range), total);
@@ -156,6 +172,7 @@ async fn handle(mut stream: TcpStream, state: Arc<ServerState>) -> std::io::Resu
                 "HTTP/1.1 206 Partial Content\r\nContent-Range: bytes {start}-{end}/{reported_total}\r\nContent-Length: {}\r\nETag: \"fixed-etag\"\r\nConnection: close\r\n\r\n",
                 body.len()
             );
+            state.ranged_responses.fetch_add(1, Ordering::Relaxed);
             stream.write_all(head.as_bytes()).await?;
             let cap = match mode {
                 Mode::DropAfter { bytes, times } if times > 0 => {
@@ -242,6 +259,7 @@ fn fast_options() -> DownloadOptions {
         progress_interval: Duration::from_millis(50),
         grow_after_successes: 4,
         max_consecutive_failures: 20,
+        upgrade_probe_interval: Duration::from_millis(150),
         budget: None,
     }
 }
@@ -394,6 +412,34 @@ async fn falls_back_to_single_stream_when_ranges_ignored() {
 
     assert!(matches!(result, Ok(Outcome::Completed)), "{result:?}");
     assert_eq!(std::fs::read(&paths.target).unwrap(), data);
+}
+
+#[tokio::test]
+async fn upgrades_to_segmented_when_ranges_become_available() {
+    let data = test_data(2 * 1024 * 1024);
+    // 前两个请求（探测 + 单流 GET）无视 Range，之后正常——模拟 CDN 冷缓存。
+    let server = Server::start(
+        data.clone(),
+        Mode::IgnoreRangeFirst(2),
+        Duration::from_millis(2),
+    )
+    .await;
+    let paths = run_paths();
+
+    let (result, progress) = run_download(
+        request(server.url("/cold-cache"), &paths.target, data.len() as u64),
+        fast_options(),
+    )
+    .await;
+
+    assert!(matches!(result, Ok(Outcome::Completed)), "{result:?}");
+    assert_eq!(std::fs::read(&paths.target).unwrap(), data);
+    assert!(
+        server.ranged_responses() >= 2,
+        "下载应升级到分段模式，实际 206 响应数: {}",
+        server.ranged_responses()
+    );
+    assert_eq!(progress.phase, Phase::Done);
 }
 
 #[tokio::test]

--- a/src-tauri/src/install/archive.rs
+++ b/src-tauri/src/install/archive.rs
@@ -325,6 +325,21 @@ fn ensure_success(
             ArchiveError::PasswordRequired
         });
     }
+    // 任务错误里只放摘要，完整输出尾部进日志供排查。
+    let tail: Vec<&str> = {
+        let mut lines: Vec<&str> = stderr
+            .lines()
+            .chain(stdout.lines())
+            .map(str::trim)
+            .filter(|line| !line.is_empty())
+            .collect();
+        lines.split_off(lines.len().saturating_sub(15))
+    };
+    log::error!(
+        "7-Zip {action}失败（退出码 {}），输出尾部:\n{}",
+        output.status.code().unwrap_or(-1),
+        tail.join("\n")
+    );
     // 末行往往只是错误计数汇总；一并带上前几条具体错误，便于区分磁盘空间、
     // 路径、数据损坏等不同原因。
     let mut details: Vec<&str> = stderr

--- a/src-tauri/src/install/archive.rs
+++ b/src-tauri/src/install/archive.rs
@@ -325,6 +325,12 @@ fn ensure_success(
             ArchiveError::PasswordRequired
         });
     }
+    // zstd 变体 7z 等非标准编解码器：字节完好但内置 7-Zip 解不开，重试无意义。
+    if stderr.contains("Unsupported Method") || stdout.contains("Unsupported Method") {
+        return Err(ArchiveError::Other(
+            "压缩包使用了内置 7-Zip 不支持的压缩算法（常见于 zstd 变体 7z），请联系资源提供方改用标准压缩算法".to_string(),
+        ));
+    }
     // 任务错误里只放摘要，完整输出尾部进日志供排查。
     let tail: Vec<&str> = {
         let mut lines: Vec<&str> = stderr

--- a/src-tauri/src/install/archive.rs
+++ b/src-tauri/src/install/archive.rs
@@ -325,12 +325,30 @@ fn ensure_success(
             ArchiveError::PasswordRequired
         });
     }
-    let detail = stderr
+    // 末行往往只是错误计数汇总；一并带上前几条具体错误，便于区分磁盘空间、
+    // 路径、数据损坏等不同原因。
+    let mut details: Vec<&str> = stderr
+        .lines()
+        .chain(stdout.lines())
+        .map(str::trim)
+        .filter(|line| line.starts_with("ERROR"))
+        .take(3)
+        .collect();
+    if let Some(summary) = stderr
         .lines()
         .chain(stdout.lines())
         .rev()
-        .find(|line| !line.trim().is_empty())
-        .unwrap_or("未知错误");
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        && !details.contains(&summary)
+    {
+        details.push(summary);
+    }
+    let detail = if details.is_empty() {
+        "未知错误".to_string()
+    } else {
+        details.join("；")
+    };
     Err(ArchiveError::Other(format!(
         "7-Zip {action}失败（退出码 {}）: {detail}",
         output.status.code().unwrap_or(-1)

--- a/src-tauri/src/install/commands.rs
+++ b/src-tauri/src/install/commands.rs
@@ -128,9 +128,11 @@ pub async fn retry_task(
         .ok()
         .flatten()
         .is_some_and(|result| Path::new(&result.install_path).is_dir());
+    // checksum/size 不符说明已下载的数据本身有问题，必须清掉重来；
+    // url_expired 不在其列——数据没问题，换新直链后可以从断点续传。
     let reset_partial_download = matches!(
         task.error_code.as_deref(),
-        Some("checksum_mismatch" | "size_mismatch" | "url_expired")
+        Some("checksum_mismatch" | "size_mismatch")
     );
     if reset_partial_download {
         let partial_path = stored_payload
@@ -150,13 +152,22 @@ pub async fn retry_task(
     let updated_download_path = updated_payload
         .download_path(task_id)
         .map_err(|failure| failure.message)?;
-    if previous_download_path != updated_download_path && previous_download_path.exists() {
-        if updated_download_path.exists() {
+    if previous_download_path != updated_download_path {
+        // 下载数据和它的控制文件必须一起迁移，否则新路径上无法续传。
+        let sources = reina_download::artifact_paths(&previous_download_path);
+        let destinations = reina_download::artifact_paths(&updated_download_path);
+        if sources.iter().any(|path| path.exists()) && destinations.iter().any(|path| path.exists())
+        {
             return Err("新的下载临时文件已存在，请先清理冲突文件".to_string());
         }
-        tokio::fs::rename(&previous_download_path, &updated_download_path)
-            .await
-            .map_err(|error| format!("迁移下载临时文件失败: {error}"))?;
+        for (source, destination) in sources.iter().zip(&destinations) {
+            if !source.exists() {
+                continue;
+            }
+            tokio::fs::rename(source, destination)
+                .await
+                .map_err(|error| format!("迁移下载临时文件失败: {error}"))?;
+        }
     }
     let mut active: tasks::ActiveModel = task.into();
     active.title = Set(request.title.clone());

--- a/src-tauri/src/install/download.rs
+++ b/src-tauri/src/install/download.rs
@@ -7,29 +7,29 @@ use super::{
 use crate::entity::tasks;
 use crate::install::protocol::InstallRequest;
 use crate::utils::http::get_transfer_client;
+use reina_download::{
+    CancellationToken, DownloadError, DownloadOptions, DownloadRequest, Outcome, Phase, Progress,
+    SharedBudget,
+};
 use sea_orm::DatabaseConnection;
 use sha2::{Digest, Sha256};
 use std::fs::File as StdFile;
 use std::io::{BufReader, Read};
 use std::path::{Path, PathBuf};
+use std::pin::pin;
 use std::sync::OnceLock;
 use std::time::Duration;
-use takanawa_core::HashConfig;
-use takanawa_http::{
-    DownloadConfig, DownloadEngine, DownloadHandle, DownloadPhase, DownloadSnapshot, RetryConfig,
-    TimeoutConfig,
-};
-use tokio::runtime::{Builder as RuntimeBuilder, Runtime};
 use tokio::sync::watch;
 
-const TAKANAWA_CHUNK_SIZE: u64 = 64 * 1024 * 1024;
-// Takanawa 会从该上限开始，并在服务端返回 429 时按下载任务自动降低并发。
-const TAKANAWA_PARALLELISM: usize = 8;
-const TAKANAWA_MAX_IO: usize = 24;
+/// 全局连接预算：所有并行下载任务加起来的在飞连接上限。
+/// 单任务上限由 `DownloadOptions::max_connections` 决定。
+const GLOBAL_CONNECTION_BUDGET: usize = 16;
 const PROGRESS_REPORT_INTERVAL: Duration = Duration::from_millis(500);
-const CONTROL_POLL_INTERVAL: Duration = Duration::from_millis(50);
 
-static TAKANAWA_RUNTIME: OnceLock<Result<Runtime, String>> = OnceLock::new();
+fn download_budget() -> &'static SharedBudget {
+    static BUDGET: OnceLock<SharedBudget> = OnceLock::new();
+    BUDGET.get_or_init(|| SharedBudget::new(GLOBAL_CONNECTION_BUDGET))
+}
 
 pub(crate) async fn download_file(
     app: &tauri::AppHandle,
@@ -41,121 +41,124 @@ pub(crate) async fn download_file(
 ) -> Result<(), TaskFailure> {
     check_task_control(control)?;
     validate_request(request)?;
+    remove_legacy_artifacts(partial_path).await;
 
-    if let Some(existing_size) = existing_file_size(partial_path).await? {
-        if existing_size == request.size {
-            report_progress(app, db, task.id, existing_size, request.size).await?;
-            return Ok(());
-        }
-        return Err(TaskFailure::new(
-            "takanawa_target_conflict",
-            "检测到旧下载器生成的不完整临时文件；请取消并重新创建任务后测试 Takanawa 下载器",
-        ));
-    }
-
-    let runtime = takanawa_runtime()?;
-    let engine = DownloadEngine::with_client(get_transfer_client(), TAKANAWA_MAX_IO);
-    let handle = DownloadHandle::new(
-        engine,
-        DownloadConfig {
-            url: request.url.clone(),
-            target_path: partial_path.to_path_buf(),
-            chunk_size: TAKANAWA_CHUNK_SIZE,
-            parallelism: TAKANAWA_PARALLELISM,
-            max_parallel_chunks: 0,
-            retry: RetryConfig::default(),
-            timeout: TimeoutConfig {
-                connect: Duration::from_secs(10),
-                read: Duration::from_secs(60),
-                total: Duration::ZERO,
-            },
-            bytes_per_second_limit: 0,
-            hash: HashConfig::None,
+    let download_request = DownloadRequest {
+        url: request.url.clone(),
+        target: partial_path.to_path_buf(),
+        expected_size: request.size,
+        identity: match (
+            request.checksum_algo.as_deref(),
+            request.checksum.as_deref(),
+        ) {
+            (Some(algo), Some(checksum)) => Some(format!("{algo}:{checksum}")),
+            _ => None,
         },
-    );
-    handle
-        .start_on(runtime)
-        .map_err(|error| TaskFailure::new("takanawa_start_failed", error.to_string()))?;
+    };
+    let options = DownloadOptions {
+        budget: Some(download_budget().clone()),
+        ..DownloadOptions::default()
+    };
+    let (progress_sender, progress_receiver) = watch::channel(Progress::initial());
+    let cancel_token = CancellationToken::new();
+    let mut engine = pin!(reina_download::download(
+        download_request,
+        options,
+        get_transfer_client(),
+        progress_sender,
+        cancel_token.clone(),
+    ));
 
     let mut interval = tokio::time::interval(PROGRESS_REPORT_INTERVAL);
     interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-    let mut committed = u64::try_from(task.progress_current)
-        .unwrap_or(0)
-        .min(request.size);
-    let mut last_persisted = committed;
-    loop {
+    let mut last_persisted = u64::try_from(task.progress_current).unwrap_or(0);
+    // 引擎收到取消信号前最后一次收到的控制请求；watch 通道关闭视为取消。
+    let mut requested = TaskControl::Running;
+    let outcome = loop {
         tokio::select! {
+            result = &mut engine => break result,
             changed = control.changed() => {
-                if changed.is_err() {
-                    handle.cancel().map_err(takanawa_control_failure)?;
-                    return wait_for_control_completion(app, db, task.id, request, committed, &handle, TaskControl::Cancel).await;
-                }
-                let requested = *control.borrow();
-                match requested {
-                    TaskControl::Running => {}
-                    TaskControl::Pause => {
-                        handle.pause().map_err(takanawa_control_failure)?;
-                        return wait_for_control_completion(app, db, task.id, request, committed, &handle, TaskControl::Pause).await;
-                    }
-                    TaskControl::Cancel => {
-                        handle.cancel().map_err(takanawa_control_failure)?;
-                        return wait_for_control_completion(app, db, task.id, request, committed, &handle, TaskControl::Cancel).await;
-                    }
+                let next = if changed.is_err() {
+                    TaskControl::Cancel
+                } else {
+                    *control.borrow()
+                };
+                if !matches!(next, TaskControl::Running) {
+                    requested = next;
+                    cancel_token.cancel();
                 }
             }
             _ = interval.tick() => {
-                let snapshot = handle.snapshot();
-                committed = committed.max(snapshot.downloaded_bytes.min(request.size));
-                let speed = handle.speed_snapshot();
-                let persist = committed != last_persisted;
-                if persist {
-                    update_task_progress(
-                        db,
-                        task.id,
-                        committed as i64,
-                        Some(request.size as i64),
-                    )
+                let progress = *progress_receiver.borrow();
+                persist_and_emit(app, db, task.id, request, &progress, &mut last_persisted)
                     .await?;
-                }
-                report_snapshot(
-                    app,
-                    task.id,
-                    request.size,
-                    &snapshot,
-                    committed,
-                    speed.bytes_per_second,
-                    speed.received_bytes,
-                )?;
-                last_persisted = committed;
-                match snapshot.phase {
-                    DownloadPhase::Completed => return finish_download(app, db, task.id, request.size, partial_path).await,
-                    DownloadPhase::Failed => return Err(takanawa_snapshot_failure(&snapshot, handle.last_http_status(), &request.provider)),
-                    DownloadPhase::Paused => return Err(TaskFailure::new("paused", "任务已暂停")),
-                    DownloadPhase::Cancelled => return Err(TaskFailure::new("cancelled", "任务已取消")),
-                    DownloadPhase::Created
-                    | DownloadPhase::Running
-                    | DownloadPhase::Pausing
-                    | DownloadPhase::Cancelling
-                    | DownloadPhase::Starting
-                    | DownloadPhase::Allocating
-                    | DownloadPhase::Verifying => {}
-                }
             }
         }
+    };
+
+    let progress = *progress_receiver.borrow();
+    match outcome {
+        Ok(Outcome::Completed) => {
+            update_task_progress(db, task.id, request.size as i64, Some(request.size as i64))
+                .await?;
+            emit_progress(
+                app,
+                task.id,
+                "running",
+                Some("downloading"),
+                request.size as i64,
+                Some(request.size as i64),
+                Some("bytes"),
+            );
+            Ok(())
+        }
+        Ok(Outcome::Cancelled) => {
+            // 引擎已完成最后一次落盘提交；把提交水位写库后再转为暂停/取消。
+            let committed = progress.committed.min(request.size);
+            update_task_progress(db, task.id, committed as i64, Some(request.size as i64)).await?;
+            emit_download_progress(
+                app,
+                task.id,
+                committed as i64,
+                request.size as i64,
+                0.0,
+                i64::try_from(progress.written).unwrap_or(i64::MAX),
+            );
+            match requested {
+                TaskControl::Pause => Err(TaskFailure::new("paused", "任务已暂停")),
+                _ => Err(TaskFailure::new("cancelled", "任务已取消")),
+            }
+        }
+        Err(error) => Err(map_download_error(&error, &request.provider)),
     }
 }
 
-fn takanawa_runtime() -> Result<&'static Runtime, TaskFailure> {
-    match TAKANAWA_RUNTIME.get_or_init(|| {
-        RuntimeBuilder::new_multi_thread()
-            .enable_all()
-            .thread_name("reina-takanawa")
-            .build()
-            .map_err(|error| format!("创建 Takanawa runtime 失败: {error}"))
-    }) {
-        Ok(runtime) => Ok(runtime),
-        Err(message) => Err(TaskFailure::new("takanawa_init_failed", message.clone())),
+async fn persist_and_emit(
+    app: &tauri::AppHandle,
+    db: &DatabaseConnection,
+    task_id: i64,
+    request: &InstallRequest,
+    progress: &Progress,
+    last_persisted: &mut u64,
+) -> Result<(), TaskFailure> {
+    // 探测完成前引擎还没读取控制文件，此时的 0 不能覆盖续传任务的已有进度。
+    if matches!(progress.phase, Phase::Probing) {
+        return Ok(());
     }
+    let committed = progress.committed.min(request.size);
+    if committed != *last_persisted {
+        update_task_progress(db, task_id, committed as i64, Some(request.size as i64)).await?;
+        *last_persisted = committed;
+    }
+    emit_download_progress(
+        app,
+        task_id,
+        committed as i64,
+        request.size as i64,
+        progress.speed_bps,
+        i64::try_from(progress.written.min(request.size)).unwrap_or(i64::MAX),
+    );
+    Ok(())
 }
 
 fn validate_request(request: &InstallRequest) -> Result<(), TaskFailure> {
@@ -182,182 +185,64 @@ fn validate_request(request: &InstallRequest) -> Result<(), TaskFailure> {
     Ok(())
 }
 
-async fn existing_file_size(path: &Path) -> Result<Option<u64>, TaskFailure> {
-    match tokio::fs::metadata(path).await {
-        Ok(metadata) => Ok(Some(metadata.len())),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
-        Err(error) => Err(TaskFailure::new("task_file_failed", error.to_string())),
+/// 清理旧版 Takanawa 下载器遗留的临时文件；新引擎不认识这些文件。
+async fn remove_legacy_artifacts(partial_path: &Path) {
+    for suffix in [".part", ".part.lock"] {
+        let mut value = partial_path.as_os_str().to_owned();
+        value.push(suffix);
+        let path = PathBuf::from(value);
+        match tokio::fs::remove_file(&path).await {
+            Ok(()) => log::info!("已清理旧下载器临时文件: {}", path.display()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                log::warn!("清理旧下载器临时文件失败 {}: {error}", path.display());
+            }
+        }
     }
 }
 
-async fn wait_for_control_completion(
-    app: &tauri::AppHandle,
-    db: &DatabaseConnection,
-    task_id: i64,
-    request: &InstallRequest,
-    minimum_committed: u64,
-    handle: &DownloadHandle,
-    requested: TaskControl,
-) -> Result<(), TaskFailure> {
-    loop {
-        let snapshot = handle.snapshot();
-        let committed = minimum_committed.max(snapshot.downloaded_bytes.min(request.size));
-        match snapshot.phase {
-            DownloadPhase::Completed => {
-                report_progress(app, db, task_id, request.size, request.size).await?;
-                return Ok(());
-            }
-            DownloadPhase::Paused => {
-                update_task_progress(db, task_id, committed as i64, Some(request.size as i64))
-                    .await?;
-                let speed = handle.speed_snapshot();
-                report_snapshot(
-                    app,
-                    task_id,
-                    request.size,
-                    &snapshot,
-                    committed,
-                    0.0,
-                    speed.received_bytes,
-                )?;
-                return Err(TaskFailure::new("paused", "任务已暂停"));
-            }
-            DownloadPhase::Cancelled => {
-                return Err(TaskFailure::new("cancelled", "任务已取消"));
-            }
-            DownloadPhase::Failed => {
-                return Err(takanawa_snapshot_failure(
-                    &snapshot,
-                    handle.last_http_status(),
-                    &request.provider,
-                ));
-            }
-            DownloadPhase::Created
-            | DownloadPhase::Running
-            | DownloadPhase::Pausing
-            | DownloadPhase::Cancelling
-            | DownloadPhase::Starting
-            | DownloadPhase::Allocating
-            | DownloadPhase::Verifying => {}
+fn map_download_error(error: &DownloadError, provider: &str) -> TaskFailure {
+    match error.http_status() {
+        Some(401) => {
+            return TaskFailure::new(
+                "download_authorization_failed",
+                format!("下载授权已失效，请重新从资源提供方（{provider}）推送任务"),
+            );
         }
-        if matches!(requested, TaskControl::Cancel)
-            && !matches!(snapshot.phase, DownloadPhase::Cancelling)
-        {
-            handle.cancel().map_err(takanawa_control_failure)?;
+        Some(403) => {
+            return TaskFailure::new("download_request_forbidden", "下载请求被服务器拒绝");
         }
-        tokio::time::sleep(CONTROL_POLL_INTERVAL).await;
+        Some(429) => {
+            return TaskFailure::new(
+                "download_rate_limited",
+                "下载请求受到服务器限流，请稍后重试",
+            );
+        }
+        Some(502..=504) => {
+            return TaskFailure::new(
+                "download_server_unavailable",
+                "下载服务器暂时不可用，请稍后重试",
+            );
+        }
+        Some(_) | None => {}
     }
-}
-
-fn report_snapshot(
-    app: &tauri::AppHandle,
-    task_id: i64,
-    expected_size: u64,
-    snapshot: &DownloadSnapshot,
-    committed: u64,
-    bytes_per_second: f64,
-    received_bytes: u64,
-) -> Result<(), TaskFailure> {
-    if snapshot.content_len != 0 && snapshot.content_len != expected_size {
-        return Err(TaskFailure::new(
+    match error {
+        DownloadError::SizeMismatch { expected, actual } => TaskFailure::new(
             "size_mismatch",
+            format!("服务器文件大小与请求不一致：期望 {expected}，实际 {actual}"),
+        ),
+        DownloadError::TargetConflict(path) => TaskFailure::new(
+            "download_target_conflict",
             format!(
-                "服务器文件大小与请求不一致：期望 {expected_size}，实际 {}",
-                snapshot.content_len
+                "下载目标位置已有无法识别的文件，请清理后重试: {}",
+                path.display()
             ),
-        ));
-    }
-    let committed = committed.min(expected_size);
-    emit_download_progress(
-        app,
-        task_id,
-        committed as i64,
-        expected_size as i64,
-        bytes_per_second,
-        i64::try_from(received_bytes).unwrap_or(i64::MAX),
-    );
-    Ok(())
-}
-
-async fn finish_download(
-    app: &tauri::AppHandle,
-    db: &DatabaseConnection,
-    task_id: i64,
-    expected_size: u64,
-    path: &Path,
-) -> Result<(), TaskFailure> {
-    let actual_size = existing_file_size(path)
-        .await?
-        .ok_or_else(|| TaskFailure::new("task_file_failed", "Takanawa 未生成下载文件"))?;
-    if actual_size != expected_size {
-        return Err(TaskFailure::new(
-            "size_mismatch",
-            format!("下载文件大小不一致：期望 {expected_size}，实际 {actual_size}"),
-        ));
-    }
-    report_progress(app, db, task_id, actual_size, expected_size).await
-}
-
-async fn report_progress(
-    app: &tauri::AppHandle,
-    db: &DatabaseConnection,
-    task_id: i64,
-    current: u64,
-    total: u64,
-) -> Result<(), TaskFailure> {
-    update_task_progress(db, task_id, current as i64, Some(total as i64)).await?;
-    emit_progress(
-        app,
-        task_id,
-        "running",
-        Some("downloading"),
-        current as i64,
-        Some(total as i64),
-        Some("bytes"),
-    );
-    Ok(())
-}
-
-fn takanawa_control_failure(error: takanawa_core::TakanawaError) -> TaskFailure {
-    TaskFailure::new("takanawa_control_failed", error.to_string())
-}
-
-fn takanawa_snapshot_failure(
-    snapshot: &DownloadSnapshot,
-    http_status: Option<u16>,
-    provider: &str,
-) -> TaskFailure {
-    if let Some(failure) = takanawa_http_failure(http_status, provider) {
-        return failure;
-    }
-    TaskFailure::new(
-        "takanawa_download_failed",
-        snapshot
-            .last_error
-            .clone()
-            .unwrap_or_else(|| "Takanawa 下载失败".to_string()),
-    )
-}
-
-fn takanawa_http_failure(status: Option<u16>, provider: &str) -> Option<TaskFailure> {
-    match status {
-        Some(401) => Some(TaskFailure::new(
-            "download_authorization_failed",
-            format!("下载授权已失效，请重新从资源提供方（{provider}）推送任务"),
-        )),
-        Some(403) => Some(TaskFailure::new(
-            "download_request_forbidden",
-            "下载请求被服务器拒绝",
-        )),
-        Some(429) => Some(TaskFailure::new(
-            "download_rate_limited",
-            "下载请求受到服务器限流，请稍后重试",
-        )),
-        Some(502..=504) => Some(TaskFailure::new(
-            "download_server_unavailable",
-            "下载服务器暂时不可用，请稍后重试",
-        )),
-        Some(_) | None => None,
+        ),
+        DownloadError::Disk(disk_error) => {
+            TaskFailure::new("task_file_failed", disk_error.to_string())
+        }
+        DownloadError::InvalidConfig(detail) => TaskFailure::new("invalid_payload", detail.clone()),
+        other => TaskFailure::new("download_failed", other.to_string()),
     }
 }
 
@@ -467,28 +352,61 @@ mod tests {
 
     #[test]
     fn classifies_terminal_download_http_statuses() {
+        let http = |status: u16, retryable: bool| DownloadError::Http { status, retryable };
         assert_eq!(
-            takanawa_http_failure(Some(401), "sena-repo").unwrap().code,
+            map_download_error(&http(401, false), "sena-repo").code,
             "download_authorization_failed"
         );
         assert_eq!(
-            takanawa_http_failure(Some(403), "sena-repo").unwrap().code,
+            map_download_error(&http(403, false), "sena-repo").code,
             "download_request_forbidden"
         );
         assert_eq!(
-            takanawa_http_failure(Some(429), "sena-repo").unwrap().code,
+            map_download_error(&http(429, true), "sena-repo").code,
             "download_rate_limited"
         );
         for status in [502, 503, 504] {
             assert_eq!(
-                takanawa_http_failure(Some(status), "sena-repo")
-                    .unwrap()
-                    .code,
+                map_download_error(&http(status, true), "sena-repo").code,
                 "download_server_unavailable"
             );
         }
-        assert!(takanawa_http_failure(Some(500), "sena-repo").is_none());
-        assert!(takanawa_http_failure(None, "sena-repo").is_none());
+        // 状态透过重试耗尽错误也要被识别。
+        let exhausted = DownloadError::RetriesExhausted {
+            attempts: 21,
+            last: Box::new(http(429, true)),
+        };
+        assert_eq!(
+            map_download_error(&exhausted, "sena-repo").code,
+            "download_rate_limited"
+        );
+        assert_eq!(
+            map_download_error(&http(500, true), "sena-repo").code,
+            "download_failed"
+        );
+    }
+
+    #[test]
+    fn maps_non_http_errors() {
+        assert_eq!(
+            map_download_error(
+                &DownloadError::SizeMismatch {
+                    expected: 10,
+                    actual: 9
+                },
+                "p"
+            )
+            .code,
+            "size_mismatch"
+        );
+        assert_eq!(
+            map_download_error(&DownloadError::TargetConflict(PathBuf::from("/tmp/x")), "p").code,
+            "download_target_conflict"
+        );
+        assert_eq!(
+            map_download_error(&DownloadError::Disk(std::io::Error::other("boom")), "p").code,
+            "task_file_failed"
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/src/install/download.rs
+++ b/src-tauri/src/install/download.rs
@@ -129,7 +129,16 @@ pub(crate) async fn download_file(
                 _ => Err(TaskFailure::new("cancelled", "任务已取消")),
             }
         }
-        Err(error) => Err(map_download_error(&error, &request.provider)),
+        Err(error) => {
+            // 映射成用户文案前先记录原始错误类别，保留排查线索。
+            log::error!(
+                "下载失败 task_id={} kind={} status={:?}: {error}",
+                task.id,
+                error.kind(),
+                error.http_status(),
+            );
+            Err(map_download_error(&error, &request.provider))
+        }
     }
 }
 

--- a/src-tauri/src/install/persistence.rs
+++ b/src-tauri/src/install/persistence.rs
@@ -157,10 +157,15 @@ pub(crate) async fn remove_task_artifacts(
 }
 
 pub(crate) async fn remove_download_artifacts(download_path: &Path) -> Result<(), TaskFailure> {
-    let part_path = takanawa_core::part_path_for(download_path);
-    let lock_path = takanawa_core::part_lock_path_for(download_path);
+    let mut paths = reina_download::artifact_paths(download_path);
+    // 旧版 Takanawa 下载器的遗留文件，升级后一并清理。
+    for legacy_suffix in [".part", ".part.lock"] {
+        let mut value = download_path.as_os_str().to_owned();
+        value.push(legacy_suffix);
+        paths.push(std::path::PathBuf::from(value));
+    }
     let mut first_error = None;
-    for path in [download_path, part_path.as_path(), lock_path.as_path()] {
+    for path in &paths {
         match tokio::fs::remove_file(path).await {
             Ok(()) => {}
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
@@ -259,15 +264,6 @@ pub(crate) async fn fail_task(
     result: Option<Value>,
 ) -> Result<tasks::Model, TaskFailure> {
     fail_task_with_progress(db, task_id, error_code, error_message, result, None).await
-}
-
-pub(crate) async fn fail_task_and_reset_progress(
-    db: &DatabaseConnection,
-    task_id: i64,
-    error_code: &str,
-    error_message: &str,
-) -> Result<tasks::Model, TaskFailure> {
-    fail_task_with_progress(db, task_id, error_code, error_message, None, Some(0)).await
 }
 
 async fn fail_task_with_progress(

--- a/src-tauri/src/install/runner.rs
+++ b/src-tauri/src/install/runner.rs
@@ -2,9 +2,8 @@ use super::{
     download::{download_file, verify_file},
     persistence::check_task_control,
     persistence::{
-        cleanup_task_artifacts, emit_progress, fail_task, fail_task_and_reset_progress, find_task,
-        remove_download_artifacts, save_game_install_result, set_task_cancelled, set_task_paused,
-        set_task_stage,
+        cleanup_task_artifacts, emit_progress, fail_task, find_task, save_game_install_result,
+        set_task_cancelled, set_task_paused, set_task_stage,
     },
     types::{
         GAME_INSTALL_TASK_TYPE, GameInstallResultV1, TaskControl, TaskFailure, TaskRuntimeState,
@@ -70,23 +69,11 @@ pub(crate) fn spawn_task(
                         failure.code,
                         failure.message
                     );
-                    let url_expired = failure.code == "url_expired";
-                    let failed = if url_expired {
-                        fail_task_and_reset_progress(&db, task_id, &failure.code, &failure.message)
-                            .await
-                    } else {
-                        fail_task(&db, task_id, &failure.code, &failure.message, None).await
-                    };
+                    // 直链过期不再清理已下载的数据：续传身份与 URL 无关，
+                    // 用新直链重试可以从断点继续。
+                    let failed =
+                        fail_task(&db, task_id, &failure.code, &failure.message, None).await;
                     if let Ok(task) = &failed {
-                        if url_expired
-                            && let Err(cleanup_failure) = clear_expired_download(task).await
-                        {
-                            log::warn!(
-                                "清理过期下载失败 task_id={task_id} code={}: {}",
-                                cleanup_failure.code,
-                                cleanup_failure.message
-                            );
-                        }
                         emit_progress(
                             &app,
                             task_id,
@@ -104,12 +91,6 @@ pub(crate) fn spawn_task(
         app.state::<TaskRuntimeState>().finish(task_id);
     });
     Ok(())
-}
-
-async fn clear_expired_download(task: &tasks::Model) -> Result<(), TaskFailure> {
-    let payload = parse_game_install_payload(task)?;
-    let download_path = payload.download_path(task.id)?;
-    remove_download_artifacts(&download_path).await
 }
 
 fn download_semaphore() -> &'static Semaphore {

--- a/src-tauri/src/install/runner.rs
+++ b/src-tauri/src/install/runner.rs
@@ -23,7 +23,8 @@ use std::sync::OnceLock;
 use tauri::Manager;
 use tokio::sync::{Semaphore, SemaphorePermit, watch};
 
-const MAX_CONCURRENT_DOWNLOADS: usize = 1;
+// 多任务的总连接数由 download.rs 的全局连接预算约束，单任务限流时各自独立降级。
+const MAX_CONCURRENT_DOWNLOADS: usize = 3;
 const MAX_CONCURRENT_EXTRACTS: usize = 1;
 
 static DOWNLOAD_SEMAPHORE: OnceLock<Semaphore> = OnceLock::new();

--- a/src-tauri/src/utils/http/client.rs
+++ b/src-tauri/src/utils/http/client.rs
@@ -1,9 +1,6 @@
 use serde::Deserialize;
 use std::sync::{OnceLock, RwLock};
 use std::time::Duration;
-use takanawa_reqwest::{
-    Client as TransferClient, NoProxy as TransferNoProxy, Proxy as TransferProxy,
-};
 use tauri_plugin_http::reqwest::{Client, NoProxy, Proxy};
 
 const GLOBAL_USER_AGENT: &str = concat!(
@@ -23,7 +20,7 @@ pub struct ProxyConfig {
 
 struct HttpClientState {
     client: Client,
-    transfer_client: TransferClient,
+    transfer_client: Client,
     proxy_url: String,
 }
 
@@ -83,16 +80,20 @@ pub(super) fn refresh_system_proxy_clients() -> Result<bool, String> {
     Ok(true)
 }
 
-fn build_transfer_client(proxy_url: &str) -> Result<TransferClient, String> {
-    let mut builder = TransferClient::builder()
+/// 大文件传输专用客户端：不设总超时（由下载引擎的停滞检测负责），并强制
+/// HTTP/1.1 —— HTTP/2 会把多个 Range 请求复用到一条 TCP 连接上，使多连接
+/// 下载在按连接限速的 CDN 上失去意义。
+fn build_transfer_client(proxy_url: &str) -> Result<Client, String> {
+    let mut builder = Client::builder()
+        .http1_only()
         .connect_timeout(Duration::from_secs(DEFAULT_CONNECT_TIMEOUT_SECS))
         .read_timeout(Duration::from_secs(DEFAULT_TIMEOUT_SECS))
         .user_agent(GLOBAL_USER_AGENT);
 
     if !proxy_url.is_empty() {
-        let proxy = TransferProxy::all(proxy_url)
+        let proxy = Proxy::all(proxy_url)
             .map_err(|error| format!("代理地址无效: {error}"))?
-            .no_proxy(TransferNoProxy::from_string(LOCAL_PROXY_BYPASS));
+            .no_proxy(NoProxy::from_string(LOCAL_PROXY_BYPASS));
         builder = builder.proxy(proxy);
     }
 
@@ -147,7 +148,7 @@ pub fn get_client() -> Client {
         .clone()
 }
 
-pub fn get_transfer_client() -> TransferClient {
+pub fn get_transfer_client() -> Client {
     http_client()
         .read()
         .unwrap_or_else(|error| error.into_inner())


### PR DESCRIPTION
## 改动

新增 workspace crate `reina-download` 替换 takanawa（依赖 reqwest/tokio）

- **细粒度续传**：4 MiB 分片，片内记录连续已写字节数；进度存旁路控制文件，每 2 秒 fdatasync 后原子写入，只会低估不会高估。中断损失从最坏 512 MiB 降到未落盘的页缓存
- **续传身份与 URL 解耦**：身份为 size + checksum，签名直链过期后换新链接可断点续传；url_expired 不再删除已下载数据
- **连接数自适应可恢复**：429 减半并尊重 Retry-After，连续成功后回升；跨任务共享全局连接预算（16）
- **单流回退**：服务器忽略 Range 时自动降级
- **Windows 稀疏文件**：消除 NTFS 预分配同步填零导致的开局假死
- **进度双水位**：`written`（页缓存）给 UI、`committed`（落盘）持久化，独立任务 250ms 固定间隔推送，进度条不再跳变或冻结

应用侧接口与事件形状不变
传输客户端改用 tauri-plugin-http 的 reqwest（http1_only），移除 takanawa-core / takanawa-http / reqwest 0.13 / native-tls 依赖；启动下载时自动清理旧 `.part` 遗留文件。